### PR TITLE
Feature/warehouse search/switch jpmap

### DIFF
--- a/lib/Controller/WarehouseSearch/warehouse_search_top_controller.dart
+++ b/lib/Controller/WarehouseSearch/warehouse_search_top_controller.dart
@@ -1,0 +1,19 @@
+import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferences_service.dart';
+
+class WarehouseSearchTopController {
+  SharedPreferencesService sharedPreferencesService =
+      SharedPreferencesService();
+
+  late bool mapSwitch;
+  WarehouseSearchTopController() {
+    mapSwitch = true;
+  }
+  Future<bool> setMapSwitch({required bool mapSwitch}) async {
+    return sharedPreferencesService.setBool('mapSwitch', !mapSwitch);
+  }
+
+  Future<bool> getMapSwitch() async {
+    bool? isMap = await sharedPreferencesService.getBool('mapSwitch');
+    return isMap == null ? true : isMap;
+  }
+}

--- a/lib/Controller/WarehouseSearch/warehouse_search_top_controller.dart
+++ b/lib/Controller/WarehouseSearch/warehouse_search_top_controller.dart
@@ -3,8 +3,25 @@ import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferenc
 class WarehouseSearchTopController {
   SharedPreferencesService sharedPreferencesService =
       SharedPreferencesService();
-
   late bool mapSwitch;
+  List<String> areaNameList = [
+    '北海道',
+    '東北',
+    '関東',
+    '中部',
+    '近畿',
+    '中国・四国',
+    '九州',
+  ];
+  List<String> areaImageUrlList = [
+    'https://www.c-ihighway.jp/smp/img/MAP/hokkaido.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/tohoku.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/kanto.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/hokuriku.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/kinki.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/chugoku.png',
+    'https://www.c-ihighway.jp/smp/img/MAP/kyushu.png',
+  ];
   WarehouseSearchTopController() {
     mapSwitch = true;
   }

--- a/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
+++ b/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
@@ -3,55 +3,45 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/cupertino.dart';
 
 class LocalSearchCardGroup extends StatelessWidget {
-  const LocalSearchCardGroup({super.key});
+  const LocalSearchCardGroup({
+    super.key,
+    required this.areaNameList,
+    required this.areaImageUrlList,
+  });
+
+  final List<String> areaNameList;
+  final List<String> areaImageUrlList;
 
   @override
   Widget build(BuildContext context) {
     double deviceWidth = MediaQuery.of(context).size.width;
-    List<String> localArea = [
-      '北海道',
-      '東北',
-      '関東',
-      '中部',
-      '近畿',
-      '中国・四国',
-      '九州',
-    ];
-    List<String> areaImageUrl = [
-      'https://www.c-ihighway.jp/smp/img/MAP/hokkaido.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/tohoku.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/kanto.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/hokuriku.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/kinki.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/chugoku.png',
-      'https://www.c-ihighway.jp/smp/img/MAP/kyushu.png',
-    ];
     return GridView.builder(
       physics: const NeverScrollableScrollPhysics(),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
         childAspectRatio: (2 / 1),
       ),
-      itemCount: localArea.length,
+      itemCount: areaNameList.length,
       itemBuilder: (BuildContext context, int index) {
         return Padding(
           padding: const EdgeInsets.all(10),
           child: CommonCard(
             content: Align(
-                alignment: Alignment.center,
-                child: Row(
-                  children: <Widget>[
-                    SizedBox(
-                        width: deviceWidth * 0.15,
-                        child: Padding(
-                          padding: const EdgeInsets.all(5),
-                          child: Image.network(areaImageUrl[index]),
-                        )),
-                    CustomText(
-                      text: localArea[index],
-                    ),
-                  ],
-                )),
+              alignment: Alignment.center,
+              child: Row(
+                children: <Widget>[
+                  SizedBox(
+                      width: deviceWidth * 0.15,
+                      child: Padding(
+                        padding: const EdgeInsets.all(5),
+                        child: Image.network(areaImageUrlList[index]),
+                      )),
+                  CustomText(
+                    text: areaNameList[index],
+                  ),
+                ],
+              ),
+            ),
           ),
         );
       },

--- a/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
+++ b/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
@@ -1,3 +1,4 @@
+import 'package:fleet_tracker/Route/router.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Card/common_card.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/cupertino.dart';
@@ -23,23 +24,29 @@ class LocalSearchCardGroup extends StatelessWidget {
       ),
       itemCount: areaNameList.length,
       itemBuilder: (BuildContext context, int index) {
-        return Padding(
-          padding: const EdgeInsets.all(10),
-          child: CommonCard(
-            content: Align(
-              alignment: Alignment.center,
-              child: Row(
-                children: <Widget>[
-                  SizedBox(
-                      width: deviceWidth * 0.15,
-                      child: Padding(
-                        padding: const EdgeInsets.all(5),
-                        child: Image.network(areaImageUrlList[index]),
-                      )),
-                  CustomText(
-                    text: areaNameList[index],
-                  ),
-                ],
+        return GestureDetector(
+          onTap: () {
+            WarehouseSearchResultRoute(areaId: 0, areaName: areaNameList[index])
+                .push(context);
+          },
+          child: Padding(
+            padding: const EdgeInsets.all(10),
+            child: CommonCard(
+              content: Align(
+                alignment: Alignment.center,
+                child: Row(
+                  children: <Widget>[
+                    SizedBox(
+                        width: deviceWidth * 0.15,
+                        child: Padding(
+                          padding: const EdgeInsets.all(5),
+                          child: Image.network(areaImageUrlList[index]),
+                        )),
+                    CustomText(
+                      text: areaNameList[index],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
+++ b/lib/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart
@@ -1,0 +1,60 @@
+import 'package:fleet_tracker/View/Component/CustomWidget/Card/common_card.dart';
+import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
+import 'package:flutter/cupertino.dart';
+
+class LocalSearchCardGroup extends StatelessWidget {
+  const LocalSearchCardGroup({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    double deviceWidth = MediaQuery.of(context).size.width;
+    List<String> localArea = [
+      '北海道',
+      '東北',
+      '関東',
+      '中部',
+      '近畿',
+      '中国・四国',
+      '九州',
+    ];
+    List<String> areaImageUrl = [
+      'https://www.c-ihighway.jp/smp/img/MAP/hokkaido.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/tohoku.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/kanto.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/hokuriku.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/kinki.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/chugoku.png',
+      'https://www.c-ihighway.jp/smp/img/MAP/kyushu.png',
+    ];
+    return GridView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        childAspectRatio: (2 / 1),
+      ),
+      itemCount: localArea.length,
+      itemBuilder: (BuildContext context, int index) {
+        return Padding(
+          padding: const EdgeInsets.all(10),
+          child: CommonCard(
+            content: Align(
+                alignment: Alignment.center,
+                child: Row(
+                  children: <Widget>[
+                    SizedBox(
+                        width: deviceWidth * 0.15,
+                        child: Padding(
+                          padding: const EdgeInsets.all(5),
+                          child: Image.network(areaImageUrl[index]),
+                        )),
+                    CustomText(
+                      text: localArea[index],
+                    ),
+                  ],
+                )),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/View/WarehouseSearch/warehouse_search_top_view.dart
+++ b/lib/View/WarehouseSearch/warehouse_search_top_view.dart
@@ -125,7 +125,11 @@ class __WarehouseSearchTopViewState extends State<WarehouseSearchTopView> {
               child: SizedBox(
                 width: size.width,
                 height: size.width,
-                child: LocalSearchCardGroup(),
+                child: LocalSearchCardGroup(
+                  areaNameList: warehouseSearchTopController.areaNameList,
+                  areaImageUrlList:
+                      warehouseSearchTopController.areaImageUrlList,
+                ),
               ),
             ),
             Visibility(

--- a/lib/View/WarehouseSearch/warehouse_search_top_view.dart
+++ b/lib/View/WarehouseSearch/warehouse_search_top_view.dart
@@ -1,8 +1,9 @@
 import 'package:fleet_tracker/Constants/strings.dart';
+import 'package:fleet_tracker/Controller/WarehouseSearch/warehouse_search_top_controller.dart';
 import 'package:fleet_tracker/Service/Log/log_service.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Card/WarehouseSearch/japan_map_deformed.dart';
+import 'package:fleet_tracker/View/Component/CustomWidget/Card/WarehouseSearch/local_search_card_group.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Card/common_card.dart';
-import 'package:fleet_tracker/View/Component/CustomWidget/Card/WarehouseSearch/japan_map_card.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_button.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/spacer_and_divider.dart';
@@ -25,6 +26,8 @@ class WarehouseSearchTopView extends StatefulWidget {
 }
 
 class __WarehouseSearchTopViewState extends State<WarehouseSearchTopView> {
+  WarehouseSearchTopController warehouseSearchTopController =
+      WarehouseSearchTopController();
   @override
   Widget build(BuildContext context) {
     final Size size = MediaQuery.of(context).size;
@@ -34,7 +37,12 @@ class __WarehouseSearchTopViewState extends State<WarehouseSearchTopView> {
         title: '倉庫検索',
         actions: [
           IconButton(
-            onPressed: () {},
+            onPressed: () {
+              warehouseSearchTopController.mapSwitch =
+                  !warehouseSearchTopController.mapSwitch;
+              print(warehouseSearchTopController.mapSwitch);
+              setState(() {});
+            },
             icon: Icon(
               Icons.grid_view,
             ),
@@ -112,7 +120,18 @@ class __WarehouseSearchTopViewState extends State<WarehouseSearchTopView> {
                 ),
               ),
             ),
-            const JapanMapDefomed(),
+            Visibility(
+              visible: !warehouseSearchTopController.mapSwitch,
+              child: SizedBox(
+                width: size.width,
+                height: size.width,
+                child: LocalSearchCardGroup(),
+              ),
+            ),
+            Visibility(
+              visible: warehouseSearchTopController.mapSwitch,
+              child: const JapanMapDefomed(),
+            ),
             const SpacerAndDivider(topHeight: 20, bottomHeight: 10),
             //
             // お気に入りから探す表示部分


### PR DESCRIPTION
## 概要
倉庫検索タブにある地方名検索をするカード群の作成と日本地図カードとの切り替えの実装

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 地方名検索をするカード群(local_search_card_group.dart)作成
- 倉庫検索ページのcontroller(warehouse_search_top_controller.dart)作成
- 倉庫検索ページのviewの地方名検索カード群と日本地図カードの切り替え部分

※SharedPreferencesServiceについて石橋様の方から一旦スキップ命令が発令されたためcontrollerに現状出来るところまで書き、使用自体はしていません。ご理解

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda