### PR TITLE
add: エリアモード強制ロジックの追加

### DIFF
--- a/lib/Constants/Enum/shared_preferences_keys_enum.dart
+++ b/lib/Constants/Enum/shared_preferences_keys_enum.dart
@@ -1,0 +1,4 @@
+enum SharedPreferencesKeysEnum {
+  forceInvadingMode,
+  forceIsInvading,
+}

--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+import 'package:fleet_tracker/Constants/Enum/shared_preferences_keys_enum.dart';
 import 'package:fleet_tracker/Model/Data/Warehouse/search_info_data.dart';
 import 'package:fleet_tracker/Model/Data/location_data.dart';
 import 'package:fleet_tracker/Model/Data/user_data.dart';
@@ -7,6 +8,8 @@ import 'package:fleet_tracker/Model/Entity/location.dart';
 import 'package:fleet_tracker/Route/router.dart';
 import 'package:fleet_tracker/Service/API/Original/user_service.dart';
 import 'package:fleet_tracker/Service/Firebase/Authentication/authentication_service.dart';
+import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferences_service.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -36,6 +39,16 @@ class TopLoadingController {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
     ]);
+
+    /// SharedPreferences Initialize
+    SharedPreferencesService prefs = SharedPreferencesService();
+    if (kDebugMode) {
+      await prefs.getBool(SharedPreferencesKeysEnum.forceInvadingMode.name) ??
+          prefs.setBool(
+              SharedPreferencesKeysEnum.forceInvadingMode.name, false);
+      await prefs.getBool(SharedPreferencesKeysEnum.forceIsInvading.name) ??
+          prefs.setBool(SharedPreferencesKeysEnum.forceIsInvading.name, false);
+    }
 
     permissionStatus = await checkLocationPermission();
     if (!permissionStatus) {

--- a/lib/Service/Package/BackgroundLocator/background_locator_service.dart
+++ b/lib/Service/Package/BackgroundLocator/background_locator_service.dart
@@ -122,15 +122,18 @@ class BackgroundLocatorService {
       Log.echo('Observer: WarehouseSearchInfoData updated', symbol: '🔄');
 
       /// debug: isInvadingの強制
-      SharedPreferencesService prefs = SharedPreferencesService();
-      bool? forceInvadingMode =
-          await prefs.getBool(SharedPreferencesKeysEnum.forceInvadingMode.name);
-      bool? forceIsInvading =
-          await prefs.getBool(SharedPreferencesKeysEnum.forceIsInvading.name);
+      if (kDebugMode) {
+        SharedPreferencesService prefs = SharedPreferencesService();
+        bool? forceInvadingMode = await prefs
+            .getBool(SharedPreferencesKeysEnum.forceInvadingMode.name);
+        bool? forceIsInvading =
+            await prefs.getBool(SharedPreferencesKeysEnum.forceIsInvading.name);
 
-      if (forceInvadingMode!) {
-        WarehouseSearchInfoData().setIsInvading(forceIsInvading!);
-        Log.echo('Observer: isInvading forced $forceIsInvading', symbol: '🚧');
+        if (forceInvadingMode!) {
+          WarehouseSearchInfoData().setIsInvading(forceIsInvading!);
+          Log.echo('Observer: isInvading forced $forceIsInvading',
+              symbol: '🚧');
+        }
       }
     });
   }

--- a/lib/Service/Package/BackgroundLocator/background_locator_service.dart
+++ b/lib/Service/Package/BackgroundLocator/background_locator_service.dart
@@ -2,6 +2,8 @@ import 'dart:isolate';
 import 'dart:ui';
 
 import 'package:background_task/background_task.dart' as background_task;
+import 'package:fleet_tracker/Constants/Enum/shared_preferences_keys_enum.dart';
+import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferences_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
@@ -118,6 +120,18 @@ class BackgroundLocatorService {
       /// mainIsolate: APIの結果を更新
       WarehouseSearchInfoData().setData(data: searchInfo);
       Log.echo('Observer: WarehouseSearchInfoData updated', symbol: '🔄');
+
+      /// debug: isInvadingの強制
+      SharedPreferencesService prefs = SharedPreferencesService();
+      bool? forceInvadingMode =
+          await prefs.getBool(SharedPreferencesKeysEnum.forceInvadingMode.name);
+      bool? forceIsInvading =
+          await prefs.getBool(SharedPreferencesKeysEnum.forceIsInvading.name);
+
+      if (forceInvadingMode!) {
+        WarehouseSearchInfoData().setIsInvading(forceIsInvading!);
+        Log.echo('Observer: isInvading forced $forceIsInvading', symbol: '🚧');
+      }
     });
   }
 

--- a/lib/Service/Package/SharedPreferences/shared_preferences_service.dart
+++ b/lib/Service/Package/SharedPreferences/shared_preferences_service.dart
@@ -1,59 +1,66 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SharedPreferencesService {
-  late SharedPreferences _prefs;
-  SharedPreferencesService() {
-    _instance.then((prefs) => _prefs = prefs);
-  }
-
   Future<SharedPreferences> get _instance async =>
       await SharedPreferences.getInstance();
 
   Future<bool> setString(String key, String value) async {
-    return _prefs.setString(key, value);
+    final SharedPreferences prefs = await _instance;
+    return prefs.setString(key, value);
   }
 
   Future<String?> getString(String key) async {
-    return _prefs.getString(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.getString(key);
   }
 
   Future<bool> setBool(String key, bool value) async {
-    return _prefs.setBool(key, value);
+    final SharedPreferences prefs = await _instance;
+    return prefs.setBool(key, value);
   }
 
   Future<bool?> getBool(String key) async {
-    return _prefs.getBool(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.getBool(key);
   }
 
   Future<bool> setInt(String key, int value) async {
-    return _prefs.setInt(key, value);
+    final SharedPreferences prefs = await _instance;
+    return prefs.setInt(key, value);
   }
 
   Future<int?> getInt(String key) async {
-    return _prefs.getInt(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.getInt(key);
   }
 
   Future<bool> setDouble(String key, double value) async {
-    return _prefs.setDouble(key, value);
+    final SharedPreferences prefs = await _instance;
+    return prefs.setDouble(key, value);
   }
 
   Future<double?> getDouble(String key) async {
-    return _prefs.getDouble(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.getDouble(key);
   }
 
   Future<bool> setStringList(String key, List<String> value) async {
-    return _prefs.setStringList(key, value);
+    final SharedPreferences prefs = await _instance;
+    return prefs.setStringList(key, value);
   }
 
   Future<List<String>?> getStringList(String key) async {
-    return _prefs.getStringList(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.getStringList(key);
   }
 
   Future<bool> remove(String key) async {
-    return _prefs.remove(key);
+    final SharedPreferences prefs = await _instance;
+    return prefs.remove(key);
   }
 
   Future<bool> clear() async {
-    return _prefs.clear();
+    final SharedPreferences prefs = await _instance;
+    return prefs.clear();
   }
 }

--- a/lib/View/Component/CustomWidget/Modal/debug_modal.dart
+++ b/lib/View/Component/CustomWidget/Modal/debug_modal.dart
@@ -2,13 +2,19 @@ import 'package:fleet_tracker/Controller/Setting/setting_top_controller.dart';
 import 'package:fleet_tracker/Model/Data/Warehouse/search_info_data.dart';
 import 'package:fleet_tracker/Model/Entity/Warehouse/area.dart';
 import 'package:fleet_tracker/Model/Entity/Warehouse/search_info.dart';
+import 'package:fleet_tracker/Service/Log/log_service.dart';
 import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferences_service.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Modal/custom_modal.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Setting/setting_tile_cell.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../Constants/Enum/shared_preferences_keys_enum.dart';
+
 class DebugModal {
+  SharedPreferencesService prefs = SharedPreferencesService();
+
   showModal({
     required BuildContext context,
     required Size size,
@@ -17,24 +23,56 @@ class DebugModal {
       context: context,
       size: size,
       title: '開発用設定',
-      content: Consumer(
-        builder: (context, ref, _) {
-          final warehouseSearchInfo =
-              ref.watch(warehouseSearchInfoDataProvider);
-          return Column(
-            children: [
-              SettingTileCell().withSwitch(
-                  subTitle: 'エリア内モード',
-                  cellAction: (bool value) {
-                    bool flagInvading =
-                        warehouseSearchInfo.getData().isInvading;
-                    WarehouseSearchInfoData().setIsInvading(!flagInvading);
+      content: StatefulBuilder(builder: (context, setState) {
+        return Column(
+          children: [
+            FutureBuilder(
+              future: prefs
+                  .getBool(SharedPreferencesKeysEnum.forceInvadingMode.name),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                }
+                return SettingTileCell().withSwitch(
+                  subTitle: 'エリアモードを強制する',
+                  cellAction: (bool value) async {
+                    bool forceInvadingMode = snapshot.data as bool;
+                    await prefs.setBool(
+                        SharedPreferencesKeysEnum.forceInvadingMode.name,
+                        !forceInvadingMode);
+                    Log.echo('エリアモード強制: ${!(forceInvadingMode)}');
+                    setState(() {});
                   },
-                  switchValue: warehouseSearchInfo.getData().isInvading)
-            ],
-          );
-        },
-      ),
+                  switchValue: snapshot.data as bool,
+                );
+              },
+            ),
+            FutureBuilder(
+              future:
+                  prefs.getBool(SharedPreferencesKeysEnum.forceIsInvading.name),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                }
+                return SettingTileCell().withSwitch(
+                  subTitle: snapshot.data as bool ? 'エリアIN' : 'エリアOUT',
+                  cellAction: (bool value) async {
+                    bool forceIsInvading = snapshot.data as bool;
+                    WarehouseSearchInfoData().setIsInvading(!forceIsInvading);
+                    await prefs.setBool(
+                        SharedPreferencesKeysEnum.forceIsInvading.name,
+                        !forceIsInvading);
+                    Log.echo('エリアIN/OUT強制: ${!(forceIsInvading)}');
+                    WarehouseSearchInfoData().setIsInvading(!forceIsInvading);
+                    setState(() {});
+                  },
+                  switchValue: snapshot.data as bool,
+                );
+              },
+            ),
+          ],
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
## 概要
エリアモードを強制する

## 変更点
- SharedPreferencesServiceをもとに戻す
- 開発者設定はStateで管理するように変更
- BackgroundLocatorObserverがSharedPreferencesに応じて値を強制

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda