### PR TITLE
Feature/traffic information/controller

### DIFF
--- a/lib/Constants/Enum/congestion_type_enum.dart
+++ b/lib/Constants/Enum/congestion_type_enum.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+enum CongestionTypeEnum {
+  empty,
+  crowd,
+  full,
+}
+
+class CongestionType {
+  late CongestionTypeEnum type;
+  CongestionType(String rowType) {
+    switch (rowType) {
+      case '空':
+        type = CongestionTypeEnum.empty;
+        break;
+      case '混':
+        type = CongestionTypeEnum.crowd;
+        break;
+      case '満':
+        type = CongestionTypeEnum.full;
+        break;
+      default:
+        throw Exception('Unknown type: $rowType');
+    }
+  }
+
+  Color color() {
+    switch (type) {
+      case CongestionTypeEnum.empty:
+        return Colors.green;
+      case CongestionTypeEnum.crowd:
+        return Colors.orange;
+      case CongestionTypeEnum.full:
+        return Colors.red;
+      default:
+        return Colors.green;
+    }
+  }
+}

--- a/lib/Constants/Enum/congestion_type_enum.dart
+++ b/lib/Constants/Enum/congestion_type_enum.dart
@@ -33,7 +33,7 @@ class CongestionType {
       case CongestionTypeEnum.full:
         return Colors.red;
       default:
-        return Colors.green;
+        throw Exception('Unknown type: $type');
     }
   }
 }

--- a/lib/Constants/Enum/traffic_detail_state_enum.dart
+++ b/lib/Constants/Enum/traffic_detail_state_enum.dart
@@ -17,4 +17,15 @@ class TrafficDetailStateType {
         throw Exception('Unknown type: $rowType');
     }
   }
+
+  String JapaneseText() {
+    switch (type) {
+      case TrafficDetailState.closure:
+        return '通行止・規制';
+      case TrafficDetailState.jam:
+        return '渋滞';
+      default:
+        throw Exception('Unknown type: $type');
+    }
+  }
 }

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,0 +1,67 @@
+import 'dart:ffi';
+
+import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
+import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
+
+class TrafficInformationDetailController {
+  TrafficInformationService trafficInformationService =
+      TrafficInformationService();
+
+  Future<List<Map<String, dynamic>>?> getJamInfoList(roadId) async {
+    late String type;
+    String supplementInfo;
+    List<Map<String, dynamic>> jamInfoList = [];
+    List<Map<String, dynamic>> test = [
+      {
+        'direction': '函館方面',
+        'place': '境古河IC→五霞IC',
+        'type': '通行止',
+        'supplementInfo': '工事',
+      },
+      {
+        'direction': '上り',
+        'place': '所沢IC付近',
+        'type': '渋滞',
+        'supplementInfo': '20km',
+      }
+    ];
+
+    TrafficDetail? trafficDetail =
+        await trafficInformationService.getTrafficDetail(roadId: 7);
+    if (trafficDetail == null) {
+      return null;
+    }
+
+    for (int i = 0; i < trafficDetail.data.issues.length; i++) {
+      Map<String, dynamic> jamInfoMap = {};
+      String? supplementInfo;
+      String direction = trafficDetail.data.issues[i].direction;
+      String place = trafficDetail.data.issues[i].place;
+      TrafficDetailState originaltype = trafficDetail.data.issues[i].type;
+      if (originaltype == TrafficDetailState.jam) {
+        type = '渋滞';
+      } else {
+        type = '通行止・規制';
+      }
+
+      if (trafficDetail.data.issues[i].content != null) {
+        supplementInfo = trafficDetail.data.issues[i].content;
+      } else if (trafficDetail.data.issues[i].range != null) {
+        supplementInfo = trafficDetail.data.issues[i].range;
+      } else if (trafficDetail.data.issues[i].reason != null) {
+        supplementInfo = trafficDetail.data.issues[i].reason;
+      }
+      jamInfoMap.addAll({
+        'direction': direction,
+        'place': place,
+        'type': type,
+        'supplementInfo': supplementInfo,
+      });
+
+      jamInfoList.addAll({jamInfoMap});
+    }
+    print(jamInfoList);
+    return test;
+  }
+}

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,7 +1,8 @@
 import 'package:fleet_tracker/Constants/Enum/congestion_type_enum.dart';
-import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/issue.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/sapa.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/sapa_info.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -10,147 +11,36 @@ class TrafficInformationDetailController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<Map<String, dynamic>?> getRoadInfoMap(roadId) async {
-    DateTime? timestamp;
-    final formatter = DateFormat('h:m');
-    Map<String, dynamic> test = {
-      'areaName': '関東',
-      'roadName': '東京湾アクアライン',
-      'time': timestamp,
-    };
-
-    TrafficDetail? trafficDetail =
-        await trafficInformationService.getTrafficDetail(roadId: 7);
-    if (trafficDetail == null) {
-      return null;
-    }
-    String areaName = trafficDetail.data.areaName;
-    String roadName = trafficDetail.data.roadName;
-    DateTime dateTime = trafficDetail.summary.updateTimestamp;
-    String time = formatter.format(dateTime).toString();
-    Map<String, String> roadInfoMap = {
-      'areaName': areaName,
-      'roadName': roadName,
-      'time': time,
-    };
-    print(roadInfoMap);
-    return roadInfoMap;
-  }
-
-  Future<List<Map<String, dynamic>>?> getJamInfoList(roadId) async {
-    late String type;
-    List<Map<String, dynamic>> jamInfoList = [];
-    List<Map<String, dynamic>> test = [
-      {
-        'direction': '函館方面',
-        'place': '境古河IC→五霞IC',
-        'type': '通行止',
-        'supplementInfo': '工事',
-      },
-      {
-        'direction': '上り',
-        'place': '所沢IC付近',
-        'type': '渋滞',
-        'supplementInfo': '20km',
-      }
-    ];
-
+  Future<TrafficDetail?> getRoadInfoMap(roadId) async {
     TrafficDetail? trafficDetail =
         await trafficInformationService.getTrafficDetail(roadId: 7);
     if (trafficDetail == null) {
       return null;
     }
 
-    for (int i = 0; i < trafficDetail.data.issues.length; i++) {
-      Map<String, dynamic> jamInfoMap = {};
-      String? supplementInfo = '';
-      String direction = trafficDetail.data.issues[i].direction;
-      String place = trafficDetail.data.issues[i].place;
-      TrafficDetailState originaltype = trafficDetail.data.issues[i].type;
-      if (originaltype == TrafficDetailState.jam) {
-        type = '渋滞';
-      } else {
-        type = '通行止・規制';
-      }
-
-      if (trafficDetail.data.issues[i].content != null) {
-        supplementInfo = trafficDetail.data.issues[i].content;
-      } else if (trafficDetail.data.issues[i].range != null) {
-        supplementInfo = trafficDetail.data.issues[i].range;
-      } else if (trafficDetail.data.issues[i].reason != null) {
-        supplementInfo = trafficDetail.data.issues[i].reason;
-      }
-      jamInfoMap.addAll({
-        'direction': direction,
-        'place': place,
-        'type': type,
-        'supplementInfo': supplementInfo,
-      });
-
-      jamInfoList.addAll({jamInfoMap});
-    }
-    print(jamInfoList);
-    return jamInfoList;
+    return trafficDetail;
   }
 
-  Future<List<Map<String, dynamic>>?> getSapaInfoList(roadId) async {
-    List<Map<String, dynamic>> sapaInfoList = [];
-    List<Map<String, dynamic>> test = [
-      {
-        'name': '佐野ＳＡ',
-        'direction': '上り',
-        'totalCongestion': '空',
-        'smallCarCongestion': '空',
-        'largeCarCongestion': '混',
-        'totalCongestionColor': Colors.green,
-        'smallCarCongestionColor': Colors.green,
-        'largeCarCongestionColor': Colors.orange,
-      },
-      {
-        'name': '佐野ＳＡ',
-        'direction': '下り',
-        'totalCongestion': '満',
-        'smallCarCongestion': '満',
-        'largeCarCongestion': '混',
-        'totalCongestionColor': Colors.red,
-        'smallCarCongestionColor': Colors.red,
-        'largeCarCongestionColor': Colors.orange,
-      },
-    ];
+  Future<List<TrafficIssue>?> getJamInfoList(roadId) async {
+    TrafficDetail? trafficDetail =
+        await trafficInformationService.getTrafficDetail(roadId: 7);
+    if (trafficDetail == null) {
+      return null;
+    }
+    return trafficDetail.data.issues;
+  }
+
+  Future<List<TrafficSapaInfo>?> getSapaInfoList(roadId) async {
     TrafficSapa? trafficSapa =
         await trafficInformationService.getTrafficSapa(roadId: 8);
     if (trafficSapa == null) {
       return null;
     }
-    print(trafficSapa.data.sapaInfoList.length);
-    for (int i = 0; i < trafficSapa.data.sapaInfoList.length; i++) {
-      Map<String, dynamic> sapaInfoMap = {};
-      String name = trafficSapa.data.sapaInfoList[i].name;
-      String direction = trafficSapa.data.sapaInfoList[i].direction;
-      String totalCongestion = trafficSapa.data.sapaInfoList[i].totalCongestion;
-      String smallCarCongestion =
-          trafficSapa.data.sapaInfoList[i].smallCarCongestion;
-      String largeCarCongestion =
-          trafficSapa.data.sapaInfoList[i].largeCarCongestion;
-      Color totalCongestionColor = CongestionType(totalCongestion).color();
-      Color smallCarCongestionColor =
-          CongestionType(smallCarCongestion).color();
-      Color largeCarCongestionColor =
-          CongestionType(largeCarCongestion).color();
-      sapaInfoMap.addAll({
-        'name': name,
-        'direction': direction,
-        'totalCongestion': totalCongestion,
-        'smallCarCongestion': smallCarCongestion,
-        'largeCarCongestion': largeCarCongestion,
-        'totalCongestionColor': totalCongestionColor,
-        'smallCarCongestionColor': smallCarCongestionColor,
-        'largeCarCongestionColor': largeCarCongestionColor,
-      });
-      sapaInfoList.addAll({sapaInfoMap});
-    }
-    print(sapaInfoList);
+    return trafficSapa.data.sapaInfoList;
+  }
 
-    return test;
+  String formatDateTime(DateTime updateTimestamp) {
+    final formatter = DateFormat('h:m');
+    return formatter.format(updateTimestamp).toString();
   }
 }

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
@@ -10,7 +8,6 @@ class TrafficInformationDetailController {
 
   Future<List<Map<String, dynamic>>?> getJamInfoList(roadId) async {
     late String type;
-    String supplementInfo;
     List<Map<String, dynamic>> jamInfoList = [];
     List<Map<String, dynamic>> test = [
       {

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,27 +1,24 @@
-import 'package:fleet_tracker/Constants/Enum/congestion_type_enum.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/issue.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/sapa.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/sapa_info.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class TrafficInformationDetailController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<TrafficDetail?> getRoadInfoMap(roadId) async {
+  Future<TrafficDetail?> getTrafficDetail(roadId) async {
     TrafficDetail? trafficDetail =
         await trafficInformationService.getTrafficDetail(roadId: 7);
     if (trafficDetail == null) {
       return null;
     }
-
     return trafficDetail;
   }
 
-  Future<List<TrafficIssue>?> getJamInfoList(roadId) async {
+  Future<List<TrafficIssue>?> getTrafficIssueList(roadId) async {
     TrafficDetail? trafficDetail =
         await trafficInformationService.getTrafficDetail(roadId: 7);
     if (trafficDetail == null) {
@@ -30,7 +27,7 @@ class TrafficInformationDetailController {
     return trafficDetail.data.issues;
   }
 
-  Future<List<TrafficSapaInfo>?> getSapaInfoList(roadId) async {
+  Future<List<TrafficSapaInfo>?> getTrafficSapaInfoList(roadId) async {
     TrafficSapa? trafficSapa =
         await trafficInformationService.getTrafficSapa(roadId: 8);
     if (trafficSapa == null) {

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -9,7 +9,7 @@ class TrafficInformationDetailController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<TrafficDetail?> getTrafficDetail(roadId) async {
+  Future<TrafficDetail?> getTrafficDetail(int roadId) async {
     TrafficDetail? trafficDetail =
         await trafficInformationService.getTrafficDetail(roadId: 7);
     if (trafficDetail == null) {
@@ -18,7 +18,7 @@ class TrafficInformationDetailController {
     return trafficDetail;
   }
 
-  Future<List<TrafficIssue>?> getTrafficIssueList(roadId) async {
+  Future<List<TrafficIssue>?> getTrafficIssueList(int roadId) async {
     TrafficDetail? trafficDetail =
         await trafficInformationService.getTrafficDetail(roadId: 7);
     if (trafficDetail == null) {
@@ -27,7 +27,7 @@ class TrafficInformationDetailController {
     return trafficDetail.data.issues;
   }
 
-  Future<List<TrafficSapaInfo>?> getTrafficSapaInfoList(roadId) async {
+  Future<List<TrafficSapaInfo>?> getTrafficSapaInfoList(int roadId) async {
     TrafficSapa? trafficSapa =
         await trafficInformationService.getTrafficSapa(roadId: 8);
     if (trafficSapa == null) {

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -4,6 +4,7 @@ import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/sapa.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class TrafficInformationDetailController {
   TrafficInformationService trafficInformationService =
@@ -11,6 +12,7 @@ class TrafficInformationDetailController {
 
   Future<Map<String, dynamic>?> getRoadInfoMap(roadId) async {
     DateTime? timestamp;
+    final formatter = DateFormat('h:m');
     Map<String, dynamic> test = {
       'areaName': '関東',
       'roadName': '東京湾アクアライン',
@@ -24,12 +26,14 @@ class TrafficInformationDetailController {
     }
     String areaName = trafficDetail.data.areaName;
     String roadName = trafficDetail.data.roadName;
-    DateTime time = trafficDetail.summary.updateTimestamp;
-    Map<String, dynamic> roadInfoMap = {
+    DateTime dateTime = trafficDetail.summary.updateTimestamp;
+    String time = formatter.format(dateTime).toString();
+    Map<String, String> roadInfoMap = {
       'areaName': areaName,
       'roadName': roadName,
       'time': time,
     };
+    print(roadInfoMap);
     return roadInfoMap;
   }
 
@@ -59,7 +63,7 @@ class TrafficInformationDetailController {
 
     for (int i = 0; i < trafficDetail.data.issues.length; i++) {
       Map<String, dynamic> jamInfoMap = {};
-      String? supplementInfo;
+      String? supplementInfo = '';
       String direction = trafficDetail.data.issues[i].direction;
       String place = trafficDetail.data.issues[i].place;
       TrafficDetailState originaltype = trafficDetail.data.issues[i].type;

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,11 +1,37 @@
+import 'package:fleet_tracker/Constants/Enum/congestion_type_enum.dart';
 import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/sapa.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
+import 'package:flutter/material.dart';
 
 class TrafficInformationDetailController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
+
+  Future<Map<String, dynamic>?> getRoadInfoMap(roadId) async {
+    DateTime? timestamp;
+    Map<String, dynamic> test = {
+      'areaName': '関東',
+      'roadName': '東京湾アクアライン',
+      'time': timestamp,
+    };
+
+    TrafficDetail? trafficDetail =
+        await trafficInformationService.getTrafficDetail(roadId: 7);
+    if (trafficDetail == null) {
+      return null;
+    }
+    String areaName = trafficDetail.data.areaName;
+    String roadName = trafficDetail.data.roadName;
+    DateTime time = trafficDetail.summary.updateTimestamp;
+    Map<String, dynamic> roadInfoMap = {
+      'areaName': areaName,
+      'roadName': roadName,
+      'time': time,
+    };
+    return roadInfoMap;
+  }
 
   Future<List<Map<String, dynamic>>?> getJamInfoList(roadId) async {
     late String type;
@@ -60,25 +86,31 @@ class TrafficInformationDetailController {
       jamInfoList.addAll({jamInfoMap});
     }
     print(jamInfoList);
-    return test;
+    return jamInfoList;
   }
 
-  Future<List<Map<String, String>>?> getSapaInfoList(roadId) async {
-    List<Map<String, String>> sapaInfoList = [];
-    List<Map<String, String>> test = [
+  Future<List<Map<String, dynamic>>?> getSapaInfoList(roadId) async {
+    List<Map<String, dynamic>> sapaInfoList = [];
+    List<Map<String, dynamic>> test = [
       {
         'name': '佐野ＳＡ',
         'direction': '上り',
         'totalCongestion': '空',
         'smallCarCongestion': '空',
-        'largeCarCongestion': '混'
+        'largeCarCongestion': '混',
+        'totalCongestionColor': Colors.green,
+        'smallCarCongestionColor': Colors.green,
+        'largeCarCongestionColor': Colors.orange,
       },
       {
         'name': '佐野ＳＡ',
         'direction': '下り',
         'totalCongestion': '満',
         'smallCarCongestion': '満',
-        'largeCarCongestion': '混'
+        'largeCarCongestion': '混',
+        'totalCongestionColor': Colors.red,
+        'smallCarCongestionColor': Colors.red,
+        'largeCarCongestionColor': Colors.orange,
       },
     ];
     TrafficSapa? trafficSapa =
@@ -88,7 +120,7 @@ class TrafficInformationDetailController {
     }
     print(trafficSapa.data.sapaInfoList.length);
     for (int i = 0; i < trafficSapa.data.sapaInfoList.length; i++) {
-      Map<String, String> sapaInfoMap = {};
+      Map<String, dynamic> sapaInfoMap = {};
       String name = trafficSapa.data.sapaInfoList[i].name;
       String direction = trafficSapa.data.sapaInfoList[i].direction;
       String totalCongestion = trafficSapa.data.sapaInfoList[i].totalCongestion;
@@ -96,12 +128,20 @@ class TrafficInformationDetailController {
           trafficSapa.data.sapaInfoList[i].smallCarCongestion;
       String largeCarCongestion =
           trafficSapa.data.sapaInfoList[i].largeCarCongestion;
+      Color totalCongestionColor = CongestionType(totalCongestion).color();
+      Color smallCarCongestionColor =
+          CongestionType(smallCarCongestion).color();
+      Color largeCarCongestionColor =
+          CongestionType(largeCarCongestion).color();
       sapaInfoMap.addAll({
         'name': name,
         'direction': direction,
         'totalCongestion': totalCongestion,
         'smallCarCongestion': smallCarCongestion,
         'largeCarCongestion': largeCarCongestion,
+        'totalCongestionColor': totalCongestionColor,
+        'smallCarCongestionColor': smallCarCongestionColor,
+        'largeCarCongestionColor': largeCarCongestionColor,
       });
       sapaInfoList.addAll({sapaInfoMap});
     }

--- a/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
+++ b/lib/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart
@@ -1,5 +1,6 @@
 import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
 import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/sapa.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
 
 class TrafficInformationDetailController {
@@ -59,6 +60,53 @@ class TrafficInformationDetailController {
       jamInfoList.addAll({jamInfoMap});
     }
     print(jamInfoList);
+    return test;
+  }
+
+  Future<List<Map<String, String>>?> getSapaInfoList(roadId) async {
+    List<Map<String, String>> sapaInfoList = [];
+    List<Map<String, String>> test = [
+      {
+        'name': '佐野ＳＡ',
+        'direction': '上り',
+        'totalCongestion': '空',
+        'smallCarCongestion': '空',
+        'largeCarCongestion': '混'
+      },
+      {
+        'name': '佐野ＳＡ',
+        'direction': '下り',
+        'totalCongestion': '満',
+        'smallCarCongestion': '満',
+        'largeCarCongestion': '混'
+      },
+    ];
+    TrafficSapa? trafficSapa =
+        await trafficInformationService.getTrafficSapa(roadId: 8);
+    if (trafficSapa == null) {
+      return null;
+    }
+    print(trafficSapa.data.sapaInfoList.length);
+    for (int i = 0; i < trafficSapa.data.sapaInfoList.length; i++) {
+      Map<String, String> sapaInfoMap = {};
+      String name = trafficSapa.data.sapaInfoList[i].name;
+      String direction = trafficSapa.data.sapaInfoList[i].direction;
+      String totalCongestion = trafficSapa.data.sapaInfoList[i].totalCongestion;
+      String smallCarCongestion =
+          trafficSapa.data.sapaInfoList[i].smallCarCongestion;
+      String largeCarCongestion =
+          trafficSapa.data.sapaInfoList[i].largeCarCongestion;
+      sapaInfoMap.addAll({
+        'name': name,
+        'direction': direction,
+        'totalCongestion': totalCongestion,
+        'smallCarCongestion': smallCarCongestion,
+        'largeCarCongestion': largeCarCongestion,
+      });
+      sapaInfoList.addAll({sapaInfoMap});
+    }
+    print(sapaInfoList);
+
     return test;
   }
 }

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -6,13 +6,12 @@ class TrafficInformationTopController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<List<TrafficArea>?> getPrefectureInfoList() async {
+  Future<List<TrafficArea>?> getTraffiiAreatList() async {
     TrafficAbout? trafficAbout =
         await trafficInformationService.getTrafficInformation();
     if (trafficAbout == null) {
       return null;
     }
-
     return trafficAbout.dataList;
   }
 }

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -1,0 +1,1 @@
+class TrafficInformationTopController {}

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -18,11 +18,13 @@ class TrafficInformationTopController {
             'roadId': 1,
             'name': '深川留萌道',
             'issues': true,
+            'provideSapa': false,
           },
           {
             'roadId': 1,
             'name': '道央道',
             'issues': true,
+            'provideSapa': false,
           },
         ]
       },
@@ -35,11 +37,13 @@ class TrafficInformationTopController {
             'roadId': 7,
             'name': '青森道',
             'issues': true,
+            'provideSapa': false,
           },
           {
             'roadId': 8,
             'name': '東北道',
             'issues': true,
+            'provideSapa': true,
           },
         ]
       },
@@ -64,15 +68,17 @@ class TrafficInformationTopController {
           int roadClosure = trafficAbout.dataList[i].roads[j].closure;
           int roadJam = trafficAbout.dataList[i].roads[j].jam;
           bool roadIssues = false;
-
           if (roadClosure + roadJam > 0) {
             roadIssues = true;
           }
+          bool provideSapa = trafficAbout.dataList[i].roads[j].provideSapa;
+
           Map<String, dynamic> roadInfo = {};
           roadInfo.addAll({
             'roadId': roadId,
             'name': roadName,
             'issues': roadIssues,
+            'provideSapa': provideSapa,
           });
 
           roads.addAll({roadInfo});

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -1,101 +1,18 @@
 import 'package:fleet_tracker/Model/Entity/Traffic/about.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/area.dart';
 import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
 
 class TrafficInformationTopController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<List<Map<String, dynamic>>?> getPrefectureInfoList() async {
-    List<Map<String, dynamic>> prefectureInfoList = [];
-
-    List<Map<String, dynamic>> test = [
-      {
-        'id': 1,
-        'name': '東北',
-        'totalIssues': 5,
-        'roads': [
-          {
-            'roadId': 1,
-            'name': '深川留萌道',
-            'issues': true,
-            'provideSapa': false,
-          },
-          {
-            'roadId': 1,
-            'name': '道央道',
-            'issues': true,
-            'provideSapa': false,
-          },
-        ]
-      },
-      {
-        'id': 2,
-        'name': '東北',
-        'totalIssues': 4,
-        'roads': [
-          {
-            'roadId': 7,
-            'name': '青森道',
-            'issues': true,
-            'provideSapa': false,
-          },
-          {
-            'roadId': 8,
-            'name': '東北道',
-            'issues': true,
-            'provideSapa': true,
-          },
-        ]
-      },
-    ];
-
+  Future<List<TrafficArea>?> getPrefectureInfoList() async {
     TrafficAbout? trafficAbout =
         await trafficInformationService.getTrafficInformation();
     if (trafficAbout == null) {
       return null;
     }
 
-    print('エリア数${trafficAbout.dataList.length}');
-
-    for (int i = 0; i < trafficAbout.dataList.length; i++) {
-      Map<String, dynamic> areaInfoMap = {};
-      int areaId = trafficAbout.dataList[i].id;
-      String areaName = trafficAbout.dataList[i].name;
-      int areaIssues = trafficAbout.dataList[i].totalIssues;
-      List<Map> roads = [];
-
-      for (int j = 0; j < trafficAbout.dataList[i].roads.length; j++) {
-        int roadId = trafficAbout.dataList[i].roads[j].id;
-        String roadName = trafficAbout.dataList[i].roads[j].name;
-        print('${roadId}${roadName}');
-        int roadClosure = trafficAbout.dataList[i].roads[j].closure;
-        int roadJam = trafficAbout.dataList[i].roads[j].jam;
-        bool roadIssues = false;
-        if (roadClosure + roadJam > 0) {
-          roadIssues = true;
-        }
-        bool provideSapa = trafficAbout.dataList[i].roads[j].provideSapa;
-
-        Map<String, dynamic> roadInfo = {};
-        roadInfo.addAll({
-          'roadId': roadId,
-          'name': roadName,
-          'issues': roadIssues,
-          'provideSapa': provideSapa,
-        });
-
-        roads.addAll({roadInfo});
-        areaInfoMap.addAll({
-          'areaId': areaId,
-          'name': areaName,
-          'totalIssues': areaIssues,
-          'roads': roads,
-        });
-      }
-      prefectureInfoList.addAll({areaInfoMap});
-    }
-
-    print('👑最新版${prefectureInfoList}');
-    return prefectureInfoList;
+    return trafficAbout.dataList;
   }
 }

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -5,27 +5,90 @@ class TrafficInformationTopController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  getPrefectureNameMap() async {
-    Map<String, List<String>> prefectureNameMap = {};
-    List<int> totalIssues = [];
+  Future<List<Map<String, dynamic>>?> getPrefectureNameMap() async {
+    List<Map<String, dynamic>> prefectureInfoList = [];
+
+    List<Map<String, dynamic>> test = [
+      {
+        'id': 1,
+        'name': '東北',
+        'totalIssues': 5,
+        'roads': [
+          {
+            'roadId': 1,
+            'name': '深川留萌道',
+            'issues': true,
+          },
+          {
+            'roadId': 1,
+            'name': '道央道',
+            'issues': true,
+          },
+        ]
+      },
+      {
+        'id': 2,
+        'name': '東北',
+        'totalIssues': 4,
+        'roads': [
+          {
+            'roadId': 7,
+            'name': '青森道',
+            'issues': true,
+          },
+          {
+            'roadId': 8,
+            'name': '東北道',
+            'issues': true,
+          },
+        ]
+      },
+    ];
+
     TrafficAbout? trafficAbout =
         await trafficInformationService.getTrafficInformation();
     if (trafficAbout != null) {
       print('エリア数${trafficAbout.dataList.length}');
 
       for (int i = 0; i < trafficAbout.dataList.length; i++) {
-        List<String> prefectureNameList = [];
+        Map<String, dynamic> areaInfoMap = {};
+        int areaId = trafficAbout.dataList[i].id;
+        String areaName = trafficAbout.dataList[i].name;
+        int areaIssues = trafficAbout.dataList[i].totalIssues;
+        List<Map> roads = [];
+
         for (int j = 0; j < trafficAbout.dataList[i].roads.length; j++) {
-          prefectureNameList.add(trafficAbout.dataList[i].roads[j].name);
-          print(prefectureNameList);
+          int roadId = trafficAbout.dataList[i].roads[j].id;
+          String roadName = trafficAbout.dataList[i].roads[j].name;
+          print('${roadId}${roadName}');
+          int roadClosure = trafficAbout.dataList[i].roads[j].closure;
+          int roadJam = trafficAbout.dataList[i].roads[j].jam;
+          bool roadIssues = false;
+
+          if (roadClosure + roadJam > 0) {
+            roadIssues = true;
+          }
+          Map<String, dynamic> roadInfo = {};
+          roadInfo.addAll({
+            'roadId': roadId,
+            'name': roadName,
+            'issues': roadIssues,
+          });
+
+          roads.addAll({roadInfo});
+          areaInfoMap.addAll({
+            'areaId': areaId,
+            'name': areaName,
+            'totalIssues': areaIssues,
+            'roads': roads,
+          });
         }
-        prefectureNameMap
-            .addAll({trafficAbout.dataList[i].name: prefectureNameList});
-        totalIssues.add(trafficAbout.dataList[i].totalIssues);
+        prefectureInfoList.addAll({areaInfoMap});
       }
 
-      print(prefectureNameMap);
-      print(totalIssues);
+      print('👑最新版${prefectureInfoList}');
+      return prefectureInfoList;
     }
+    return null;
   }
 }

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -5,7 +5,7 @@ class TrafficInformationTopController {
   TrafficInformationService trafficInformationService =
       TrafficInformationService();
 
-  Future<List<Map<String, dynamic>>?> getPrefectureNameMap() async {
+  Future<List<Map<String, dynamic>>?> getPrefectureInfoList() async {
     List<Map<String, dynamic>> prefectureInfoList = [];
 
     List<Map<String, dynamic>> test = [
@@ -51,50 +51,51 @@ class TrafficInformationTopController {
 
     TrafficAbout? trafficAbout =
         await trafficInformationService.getTrafficInformation();
-    if (trafficAbout != null) {
-      print('エリア数${trafficAbout.dataList.length}');
-
-      for (int i = 0; i < trafficAbout.dataList.length; i++) {
-        Map<String, dynamic> areaInfoMap = {};
-        int areaId = trafficAbout.dataList[i].id;
-        String areaName = trafficAbout.dataList[i].name;
-        int areaIssues = trafficAbout.dataList[i].totalIssues;
-        List<Map> roads = [];
-
-        for (int j = 0; j < trafficAbout.dataList[i].roads.length; j++) {
-          int roadId = trafficAbout.dataList[i].roads[j].id;
-          String roadName = trafficAbout.dataList[i].roads[j].name;
-          print('${roadId}${roadName}');
-          int roadClosure = trafficAbout.dataList[i].roads[j].closure;
-          int roadJam = trafficAbout.dataList[i].roads[j].jam;
-          bool roadIssues = false;
-          if (roadClosure + roadJam > 0) {
-            roadIssues = true;
-          }
-          bool provideSapa = trafficAbout.dataList[i].roads[j].provideSapa;
-
-          Map<String, dynamic> roadInfo = {};
-          roadInfo.addAll({
-            'roadId': roadId,
-            'name': roadName,
-            'issues': roadIssues,
-            'provideSapa': provideSapa,
-          });
-
-          roads.addAll({roadInfo});
-          areaInfoMap.addAll({
-            'areaId': areaId,
-            'name': areaName,
-            'totalIssues': areaIssues,
-            'roads': roads,
-          });
-        }
-        prefectureInfoList.addAll({areaInfoMap});
-      }
-
-      print('👑最新版${prefectureInfoList}');
-      return prefectureInfoList;
+    if (trafficAbout == null) {
+      return null;
     }
-    return null;
+
+    print('エリア数${trafficAbout.dataList.length}');
+
+    for (int i = 0; i < trafficAbout.dataList.length; i++) {
+      Map<String, dynamic> areaInfoMap = {};
+      int areaId = trafficAbout.dataList[i].id;
+      String areaName = trafficAbout.dataList[i].name;
+      int areaIssues = trafficAbout.dataList[i].totalIssues;
+      List<Map> roads = [];
+
+      for (int j = 0; j < trafficAbout.dataList[i].roads.length; j++) {
+        int roadId = trafficAbout.dataList[i].roads[j].id;
+        String roadName = trafficAbout.dataList[i].roads[j].name;
+        print('${roadId}${roadName}');
+        int roadClosure = trafficAbout.dataList[i].roads[j].closure;
+        int roadJam = trafficAbout.dataList[i].roads[j].jam;
+        bool roadIssues = false;
+        if (roadClosure + roadJam > 0) {
+          roadIssues = true;
+        }
+        bool provideSapa = trafficAbout.dataList[i].roads[j].provideSapa;
+
+        Map<String, dynamic> roadInfo = {};
+        roadInfo.addAll({
+          'roadId': roadId,
+          'name': roadName,
+          'issues': roadIssues,
+          'provideSapa': provideSapa,
+        });
+
+        roads.addAll({roadInfo});
+        areaInfoMap.addAll({
+          'areaId': areaId,
+          'name': areaName,
+          'totalIssues': areaIssues,
+          'roads': roads,
+        });
+      }
+      prefectureInfoList.addAll({areaInfoMap});
+    }
+
+    print('👑最新版${prefectureInfoList}');
+    return prefectureInfoList;
   }
 }

--- a/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
+++ b/lib/Controller/TrafficInformation/traffic_information_top_controller.dart
@@ -1,1 +1,31 @@
-class TrafficInformationTopController {}
+import 'package:fleet_tracker/Model/Entity/Traffic/about.dart';
+import 'package:fleet_tracker/Service/API/TrafficInformation/traffic_information_service.dart';
+
+class TrafficInformationTopController {
+  TrafficInformationService trafficInformationService =
+      TrafficInformationService();
+
+  getPrefectureNameMap() async {
+    Map<String, List<String>> prefectureNameMap = {};
+    List<int> totalIssues = [];
+    TrafficAbout? trafficAbout =
+        await trafficInformationService.getTrafficInformation();
+    if (trafficAbout != null) {
+      print('エリア数${trafficAbout.dataList.length}');
+
+      for (int i = 0; i < trafficAbout.dataList.length; i++) {
+        List<String> prefectureNameList = [];
+        for (int j = 0; j < trafficAbout.dataList[i].roads.length; j++) {
+          prefectureNameList.add(trafficAbout.dataList[i].roads[j].name);
+          print(prefectureNameList);
+        }
+        prefectureNameMap
+            .addAll({trafficAbout.dataList[i].name: prefectureNameList});
+        totalIssues.add(trafficAbout.dataList[i].totalIssues);
+      }
+
+      print(prefectureNameMap);
+      print(totalIssues);
+    }
+  }
+}

--- a/lib/Route/router.dart
+++ b/lib/Route/router.dart
@@ -229,11 +229,17 @@ class TrafficInformationTopRoute extends GoRouteData {
 }
 
 class TrafficInformationDetailRoute extends GoRouteData {
-  const TrafficInformationDetailRoute();
+  const TrafficInformationDetailRoute(
+      {required this.roadId, required this.provideSapa});
+  final int roadId;
+  final bool provideSapa;
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      const TrafficInformationDetailView();
+      TrafficInformationDetailView(
+        roadId: roadId,
+        provideSapa: provideSapa,
+      );
 }
 //////////////////////////////  TrafficInformation  //////////////////////////////
 

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -1,3 +1,5 @@
+import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
+import 'package:fleet_tracker/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
@@ -7,16 +9,22 @@ class JamInfoPlaceTile extends StatelessWidget {
     required this.direction,
     required this.place,
     required this.type,
-    required this.supplementInfo,
+    required this.content,
+    required this.range,
+    required this.reason,
   });
   final String direction;
   final String place;
-  final String type;
-  final String supplementInfo;
+  final TrafficDetailState type;
+  final String? content;
+  final String? range;
+  final String? reason;
 
   @override
   Widget build(BuildContext context) {
     double deviceWidth = MediaQuery.of(context).size.width;
+    TrafficInformationDetailController trafficInformationDetailController =
+        TrafficInformationDetailController();
     String test = '5km';
     return Container(
       decoration: BoxDecoration(
@@ -80,7 +88,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: type,
+                        text: type.name,
                         color: Colors.white,
                         fontSize: 16,
                       ),
@@ -89,13 +97,10 @@ class JamInfoPlaceTile extends StatelessWidget {
                   SizedBox(
                     width: 10,
                   ),
-                  Visibility(
-                    visible: supplementInfo != '',
-                    child: CustomText(
-                      text: supplementInfo,
-                      fontSize: 20,
-                      color: Colors.orange,
-                    ),
+                  CustomText(
+                    text: content == null ? range! : '$content:$reason',
+                    fontSize: 20,
+                    color: Colors.orange,
                   ),
                 ],
               ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -74,7 +74,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: '通行止・規制',
+                        text: '渋滞',
                         color: Colors.white,
                         fontSize: 16,
                       ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -4,9 +4,15 @@ import 'package:flutter/material.dart';
 class JamInfoPlaceTile extends StatelessWidget {
   const JamInfoPlaceTile({
     super.key,
-    required this.roadId,
+    required this.direction,
+    required this.place,
+    required this.type,
+    required this.supplementInfo,
   });
-  final int roadId;
+  final String direction;
+  final String place;
+  final String type;
+  final String supplementInfo;
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +47,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: '北習志野方向',
+                        text: direction,
                         fontSize: 16,
                         color: Colors.white,
                       ),
@@ -52,7 +58,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                       left: 10,
                     ),
                     child: CustomText(
-                      text: '境古河IC→五霞IC',
+                      text: place,
                       fontSize: 18,
                       color: Colors.blueAccent,
                     ),
@@ -74,7 +80,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: '渋滞',
+                        text: type,
                         color: Colors.white,
                         fontSize: 16,
                       ),
@@ -84,9 +90,9 @@ class JamInfoPlaceTile extends StatelessWidget {
                     width: 10,
                   ),
                   Visibility(
-                    visible: test != '',
+                    visible: supplementInfo != '',
                     child: CustomText(
-                      text: '${test}',
+                      text: supplementInfo,
                       fontSize: 20,
                       color: Colors.orange,
                     ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -2,7 +2,11 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
 class JamInfoPlaceTile extends StatelessWidget {
-  const JamInfoPlaceTile({super.key});
+  const JamInfoPlaceTile({
+    super.key,
+    required this.roadId,
+  });
+  final int roadId;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -1,5 +1,4 @@
 import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
-import 'package:fleet_tracker/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
@@ -23,11 +22,8 @@ class JamInfoPlaceTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     double deviceWidth = MediaQuery.of(context).size.width;
-    TrafficInformationDetailController trafficInformationDetailController =
-        TrafficInformationDetailController();
-    String test = '5km';
     return Container(
-      decoration: BoxDecoration(
+      decoration: const BoxDecoration(
         border: Border(
           bottom: BorderSide(color: Colors.grey, width: 1),
         ),
@@ -40,7 +36,7 @@ class JamInfoPlaceTile extends StatelessWidget {
         child: Column(
           children: <Widget>[
             Container(
-              margin: EdgeInsets.only(
+              margin: const EdgeInsets.only(
                 left: 10,
                 bottom: 10,
               ),
@@ -88,17 +84,17 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: type.name,
+                        text: TrafficDetailStateType(type.name).JapaneseText(),
                         color: Colors.white,
                         fontSize: 16,
                       ),
                     ),
                   ),
-                  SizedBox(
+                  const SizedBox(
                     width: 10,
                   ),
                   CustomText(
-                    text: content == null ? range! : '$content:$reason',
+                    text: content == null ? range! : '$content : $reason',
                     fontSize: 20,
                     color: Colors.orange,
                   ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -70,7 +70,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: '通行止',
+                        text: '通行止・規制',
                         color: Colors.white,
                         fontSize: 16,
                       ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart
@@ -1,3 +1,4 @@
+import 'package:fleet_tracker/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
@@ -11,10 +12,12 @@ class JamInfoTitle extends StatelessWidget {
   });
   final String areaName;
   final String roadName;
-  final String time;
+  final DateTime time;
 
   @override
   Widget build(BuildContext context) {
+    TrafficInformationDetailController trafficInformationDetailController =
+        TrafficInformationDetailController();
     double deviceWidth = MediaQuery.of(context).size.width;
     return Padding(
       padding: const EdgeInsets.all(8),
@@ -74,7 +77,8 @@ class JamInfoTitle extends StatelessWidget {
                     vertical: 4,
                   ),
                   child: CustomText(
-                    text: '最終更新 ${time} (JST)',
+                    text:
+                        '最終更新 ${trafficInformationDetailController.formatDateTime(time)} (JST)',
                     color: Colors.white,
                     fontSize: 16,
                   ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart
@@ -3,7 +3,15 @@ import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 
 class JamInfoTitle extends StatelessWidget {
-  const JamInfoTitle({super.key});
+  const JamInfoTitle({
+    super.key,
+    required this.areaName,
+    required this.roadName,
+    required this.time,
+  });
+  final String areaName;
+  final String roadName;
+  final String time;
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +46,7 @@ class JamInfoTitle extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2),
                       child: CustomText(
-                        text: '関東',
+                        text: areaName,
                         color: ColorName.jamInfoTitleColor,
                         fontSize: 28,
                       ),
@@ -52,14 +60,13 @@ class JamInfoTitle extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: <Widget>[
                 Container(
-                  child: Row(
-                    children: <Widget>[
-                      CustomText(
-                        text: '東京湾アクアライン',
-                        color: Colors.white,
-                        fontSize: 25,
-                      ),
-                    ],
+                  child: Align(
+                    alignment: Alignment.center,
+                    child: CustomText(
+                      text: roadName,
+                      color: Colors.white,
+                      fontSize: 25,
+                    ),
                   ),
                 ),
                 Padding(
@@ -67,7 +74,7 @@ class JamInfoTitle extends StatelessWidget {
                     vertical: 4,
                   ),
                   child: CustomText(
-                    text: '最終更新 19:30 (JST)',
+                    text: '最終更新 ${time} (JST)',
                     color: Colors.white,
                     fontSize: 16,
                   ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/sapa_info_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/sapa_info_tile.dart
@@ -1,10 +1,23 @@
+import 'package:fleet_tracker/Constants/Enum/congestion_type_enum.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/sapa_info_congestion_icon.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 
 class SapaInfoTile extends StatelessWidget {
-  const SapaInfoTile({super.key});
+  const SapaInfoTile({
+    super.key,
+    required this.name,
+    required this.direction,
+    required this.totalCongestion,
+    required this.smallCarCongestion,
+    required this.largeCarCongestion,
+  });
+  final String name;
+  final String direction;
+  final String totalCongestion;
+  final String smallCarCongestion;
+  final String largeCarCongestion;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +45,7 @@ class SapaInfoTile extends StatelessWidget {
                     left: 10,
                   ),
                   child: CustomText(
-                    text: '那須高原SA',
+                    text: name,
                     fontSize: 18,
                     color: ColorName.sapaNameColor,
                   ),
@@ -42,7 +55,7 @@ class SapaInfoTile extends StatelessWidget {
                     left: 10,
                   ),
                   child: CustomText(
-                    text: '(那須方向)',
+                    text: direction,
                     fontSize: 12,
                     color: ColorName.sapaNameColor,
                   ),
@@ -56,8 +69,8 @@ class SapaInfoTile extends StatelessWidget {
                     right: 10,
                   ),
                   child: SapaInfoCongestionIcon(
-                    congestion: '空',
-                    iconColor: Colors.green,
+                    congestion: totalCongestion,
+                    iconColor: CongestionType(totalCongestion).color(),
                   ),
                 ),
                 Padding(
@@ -65,8 +78,8 @@ class SapaInfoTile extends StatelessWidget {
                     right: 10,
                   ),
                   child: SapaInfoCongestionIcon(
-                    congestion: '空',
-                    iconColor: Colors.green,
+                    congestion: smallCarCongestion,
+                    iconColor: CongestionType(smallCarCongestion).color(),
                   ),
                 ),
                 Padding(
@@ -74,8 +87,8 @@ class SapaInfoTile extends StatelessWidget {
                     right: 10,
                   ),
                   child: SapaInfoCongestionIcon(
-                    congestion: '空',
-                    iconColor: Colors.green,
+                    congestion: largeCarCongestion,
+                    iconColor: CongestionType(largeCarCongestion).color(),
                   ),
                 ),
               ],

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/sapa_info_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/sapa_info_tile.dart
@@ -22,7 +22,7 @@ class SapaInfoTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
+      decoration: const BoxDecoration(
         border: Border(
           bottom: BorderSide(
             color: Colors.grey,

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -3,9 +3,11 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
 class PrefecturalRoadTile extends StatelessWidget {
-  const PrefecturalRoadTile({super.key, required this.prefecturalRoadName});
+  const PrefecturalRoadTile(
+      {super.key, required this.prefecturalRoadName, required this.roadIssues});
 
   final String prefecturalRoadName;
+  final bool roadIssues;
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +60,7 @@ class PrefecturalRoadTile extends StatelessWidget {
                     width: deviceWidth * 0.1,
                     height: deviceWidth * 0.06,
                     child: Visibility(
-                      visible: true,
+                      visible: roadIssues,
                       child: FittedBox(
                         alignment: Alignment.centerRight,
                         fit: BoxFit.fitHeight,

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -4,10 +4,14 @@ import 'package:flutter/material.dart';
 
 class PrefecturalRoadTile extends StatelessWidget {
   const PrefecturalRoadTile(
-      {super.key, required this.prefecturalRoadName, required this.roadIssues});
+      {super.key,
+      required this.prefecturalRoadName,
+      required this.roadIssues,
+      required this.roadId});
 
   final String prefecturalRoadName;
   final bool roadIssues;
+  final int roadId;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -21,7 +21,10 @@ class PrefecturalRoadTile extends StatelessWidget {
     double deviceWidth = MediaQuery.of(context).size.width;
     return GestureDetector(
       onTap: () {
-        TrafficInformationDetailRoute().push(context);
+        TrafficInformationDetailRoute(
+          roadId: roadId,
+          provideSapa: provideSapa,
+        ).push(context);
       },
       child: Container(
         width: deviceWidth,

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -3,18 +3,19 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
 class PrefecturalRoadTile extends StatelessWidget {
-  const PrefecturalRoadTile({
-    super.key,
-    required this.prefecturalRoadName,
-    required this.roadIssues,
-    required this.roadId,
-    required this.provideSapa,
-  });
+  const PrefecturalRoadTile(
+      {super.key,
+      required this.prefecturalRoadName,
+      required this.roadId,
+      required this.provideSapa,
+      required this.jam,
+      required this.closure});
 
   final String prefecturalRoadName;
-  final bool roadIssues;
   final int roadId;
   final bool provideSapa;
+  final int jam;
+  final int closure;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +71,7 @@ class PrefecturalRoadTile extends StatelessWidget {
                     width: deviceWidth * 0.1,
                     height: deviceWidth * 0.06,
                     child: Visibility(
-                      visible: roadIssues,
+                      visible: jam + closure > 0,
                       child: FittedBox(
                         alignment: Alignment.centerRight,
                         fit: BoxFit.fitHeight,

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -3,15 +3,18 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:flutter/material.dart';
 
 class PrefecturalRoadTile extends StatelessWidget {
-  const PrefecturalRoadTile(
-      {super.key,
-      required this.prefecturalRoadName,
-      required this.roadIssues,
-      required this.roadId});
+  const PrefecturalRoadTile({
+    super.key,
+    required this.prefecturalRoadName,
+    required this.roadIssues,
+    required this.roadId,
+    required this.provideSapa,
+  });
 
   final String prefecturalRoadName;
   final bool roadIssues;
   final int roadId;
+  final bool provideSapa;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart
@@ -5,13 +5,13 @@ import 'package:flutter/material.dart';
 class PrefecturalRoadTile extends StatelessWidget {
   const PrefecturalRoadTile(
       {super.key,
-      required this.prefecturalRoadName,
+      required this.roadName,
       required this.roadId,
       required this.provideSapa,
       required this.jam,
       required this.closure});
 
-  final String prefecturalRoadName;
+  final String roadName;
   final int roadId;
   final bool provideSapa;
   final int jam;
@@ -62,7 +62,7 @@ class PrefecturalRoadTile extends StatelessWidget {
                       child: Padding(
                         padding: const EdgeInsets.only(left: 8),
                         child: CustomText(
-                          text: prefecturalRoadName,
+                          text: roadName,
                         ),
                       ),
                     ),
@@ -77,7 +77,7 @@ class PrefecturalRoadTile extends StatelessWidget {
                         fit: BoxFit.fitHeight,
                         child: Icon(
                           Icons.warning,
-                          color: Colors.amber,
+                          color: jam + closure > 5 ? Colors.red : Colors.orange,
                         ),
                       ),
                     ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
@@ -75,7 +75,7 @@ class TrafficInformationTileCell extends StatelessWidget {
             children: <Widget>[
               for (int i = 0; i < prefecturalRoadList.length; i++) ...{
                 PrefecturalRoadTile(
-                  prefecturalRoadName: prefecturalRoadList[i].name,
+                  roadName: prefecturalRoadList[i].name,
                   roadId: prefecturalRoadList[i].id,
                   provideSapa: prefecturalRoadList[i].provideSapa,
                   jam: prefecturalRoadList[i].jam,

--- a/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
@@ -77,6 +77,7 @@ class TrafficInformationTileCell extends StatelessWidget {
                   prefecturalRoadName: prefecturalRoadList[i]['name'],
                   roadIssues: prefecturalRoadList[i]['issues'],
                   roadId: prefecturalRoadList[i]['roadId'],
+                  provideSapa: prefecturalRoadList[i]['provideSapa'],
                 ),
               }
             ],

--- a/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
@@ -1,3 +1,4 @@
+import 'package:fleet_tracker/Model/Entity/Traffic/road.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/prefectural_road_tile.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
@@ -15,7 +16,7 @@ class TrafficInformationTileCell extends StatelessWidget {
   final String imageUrl;
   final int count;
   final String prefectureName;
-  final List<Map> prefecturalRoadList;
+  final List<TrafficRoad> prefecturalRoadList;
 
   @override
   Widget build(BuildContext context) {
@@ -74,10 +75,11 @@ class TrafficInformationTileCell extends StatelessWidget {
             children: <Widget>[
               for (int i = 0; i < prefecturalRoadList.length; i++) ...{
                 PrefecturalRoadTile(
-                  prefecturalRoadName: prefecturalRoadList[i]['name'],
-                  roadIssues: prefecturalRoadList[i]['issues'],
-                  roadId: prefecturalRoadList[i]['roadId'],
-                  provideSapa: prefecturalRoadList[i]['provideSapa'],
+                  prefecturalRoadName: prefecturalRoadList[i].name,
+                  roadId: prefecturalRoadList[i].id,
+                  provideSapa: prefecturalRoadList[i].provideSapa,
+                  jam: prefecturalRoadList[i].jam,
+                  closure: prefecturalRoadList[i].closure,
                 ),
               }
             ],

--- a/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
@@ -15,7 +15,7 @@ class TrafficInformationTileCell extends StatelessWidget {
   final String imageUrl;
   final int count;
   final String prefectureName;
-  final List<String> prefecturalRoadList;
+  final List<Map> prefecturalRoadList;
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +74,9 @@ class TrafficInformationTileCell extends StatelessWidget {
             children: <Widget>[
               for (int i = 0; i < prefecturalRoadList.length; i++) ...{
                 PrefecturalRoadTile(
-                    prefecturalRoadName: prefecturalRoadList[i]),
+                  prefecturalRoadName: prefecturalRoadList[i]['name'],
+                  roadIssues: prefecturalRoadList[i]['issues'],
+                ),
               }
             ],
           ),

--- a/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart
@@ -76,6 +76,7 @@ class TrafficInformationTileCell extends StatelessWidget {
                 PrefecturalRoadTile(
                   prefecturalRoadName: prefecturalRoadList[i]['name'],
                   roadIssues: prefecturalRoadList[i]['issues'],
+                  roadId: prefecturalRoadList[i]['roadId'],
                 ),
               }
             ],

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -1,3 +1,4 @@
+import 'package:fleet_tracker/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/info_content_card.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart';
@@ -6,6 +7,7 @@ import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Det
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class TrafficInformationDetailView extends StatefulWidget {
   const TrafficInformationDetailView({
@@ -23,6 +25,8 @@ class TrafficInformationDetailView extends StatefulWidget {
 
 class _TrafficInformationStateDetailView
     extends State<TrafficInformationDetailView> {
+  TrafficInformationDetailController trafficInformationDetailController =
+      TrafficInformationDetailController();
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -33,31 +37,65 @@ class _TrafficInformationStateDetailView
       body: SingleChildScrollView(
         child: Column(
           children: <Widget>[
-            JamInfoTitle(),
-            SizedBox(
+            FutureBuilder<Map<String, dynamic>?>(
+                future: trafficInformationDetailController
+                    .getRoadInfoMap(widget.roadId),
+                builder: (BuildContext context,
+                    AsyncSnapshot<Map<String, dynamic>?> snapshot) {
+                  if (snapshot.hasData) {
+                    Map<String, dynamic> roadInfoMap = snapshot.data!;
+                    print(roadInfoMap);
+                    return JamInfoTitle(
+                      areaName: roadInfoMap['areaName'],
+                      roadName: roadInfoMap['roadName'],
+                      time: roadInfoMap['time'],
+                    );
+                  } else {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                }),
+            const SizedBox(
               height: 20,
             ),
-            InfoContentCard(
-              children: <Widget>[
-                for (int i = 0; i < 2; i++) ...{
-                  JamInfoPlaceTile(
-                    roadId: 7,
-                  ),
-                },
-              ],
-              title: '渋滞情報',
-            ),
-            SizedBox(
+            FutureBuilder<List<Map<String, dynamic>>?>(
+                future: trafficInformationDetailController
+                    .getJamInfoList(widget.roadId),
+                builder: (BuildContext context,
+                    AsyncSnapshot<List<Map<String, dynamic>>?> snapshot) {
+                  if (snapshot.hasData) {
+                    List<Map<String, dynamic>> jamInfoList = snapshot.data!;
+                    print(jamInfoList);
+                    return InfoContentCard(
+                      children: <Widget>[
+                        for (int i = 0; i < 2; i++) ...{
+                          JamInfoPlaceTile(
+                            direction: jamInfoList[i]['direction'],
+                            place: jamInfoList[i]['place'],
+                            type: jamInfoList[i]['type'],
+                            supplementInfo: jamInfoList[i]['supplementInfo'],
+                          ),
+                        },
+                      ],
+                      title: '渋滞情報',
+                    );
+                  } else {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                }),
+            const SizedBox(
               height: 20,
             ),
-            InfoContentCard(
-              children: <Widget>[
-                SapaInfoHeader(),
-                for (int i = 0; i < 5; i++) ...{
-                  SapaInfoTile(),
-                },
-              ],
-              title: 'SAPA情報',
+            Visibility(
+              visible: widget.provideSapa,
+              child: InfoContentCard(
+                children: <Widget>[
+                  SapaInfoHeader(),
+                  for (int i = 0; i < 5; i++) ...{
+                    SapaInfoTile(),
+                  },
+                ],
+                title: 'SAPA情報',
+              ),
             ),
           ],
         ),

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -10,7 +10,6 @@ import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Det
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class TrafficInformationDetailView extends StatefulWidget {
   const TrafficInformationDetailView({
@@ -42,12 +41,11 @@ class _TrafficInformationStateDetailView
           children: <Widget>[
             FutureBuilder<TrafficDetail?>(
                 future: trafficInformationDetailController
-                    .getRoadInfoMap(widget.roadId),
+                    .getTrafficDetail(widget.roadId),
                 builder: (BuildContext context,
                     AsyncSnapshot<TrafficDetail?> snapshot) {
                   if (snapshot.hasData) {
                     TrafficDetail trafficDetail = snapshot.data!;
-                    print(trafficDetail);
                     return JamInfoTitle(
                       areaName: trafficDetail.data.areaName,
                       roadName: trafficDetail.data.roadName,
@@ -62,15 +60,14 @@ class _TrafficInformationStateDetailView
             ),
             FutureBuilder<List<TrafficIssue>?>(
                 future: trafficInformationDetailController
-                    .getJamInfoList(widget.roadId),
+                    .getTrafficIssueList(widget.roadId),
                 builder: (BuildContext context,
                     AsyncSnapshot<List<TrafficIssue>?> snapshot) {
                   if (snapshot.hasData) {
                     List<TrafficIssue> trafficIssueList = snapshot.data!;
-                    print(trafficIssueList);
                     return InfoContentCard(
                       children: <Widget>[
-                        for (int i = 0; i < 2; i++) ...{
+                        for (int i = 0; i < trafficIssueList.length; i++) ...{
                           JamInfoPlaceTile(
                             direction: trafficIssueList[i].direction,
                             place: trafficIssueList[i].place,
@@ -92,35 +89,42 @@ class _TrafficInformationStateDetailView
             ),
             FutureBuilder<List<TrafficSapaInfo>?>(
                 future: trafficInformationDetailController
-                    .getSapaInfoList(widget.roadId),
+                    .getTrafficSapaInfoList(widget.roadId),
                 builder: (BuildContext context,
                     AsyncSnapshot<List<TrafficSapaInfo>?> snapshot) {
-                  if (snapshot.hasData) {
-                    List<TrafficSapaInfo> trafficSapaInfoList = snapshot.data!;
-                    //if
-                    return Visibility(
-                      visible: widget.provideSapa,
-                      child: InfoContentCard(
-                        children: <Widget>[
-                          SapaInfoHeader(),
-                          for (int i = 0; i < 5; i++) ...{
-                            SapaInfoTile(
-                              name: trafficSapaInfoList[i].name,
-                              direction: trafficSapaInfoList[i].direction,
-                              totalCongestion:
-                                  trafficSapaInfoList[i].totalCongestion,
-                              smallCarCongestion:
-                                  trafficSapaInfoList[i].smallCarCongestion,
-                              largeCarCongestion:
-                                  trafficSapaInfoList[i].largeCarCongestion,
-                            ),
-                          },
-                        ],
-                        title: 'SAPA情報',
-                      ),
-                    );
+                  if (widget.provideSapa) {
+                    if (snapshot.hasData) {
+                      List<TrafficSapaInfo> trafficSapaInfoList =
+                          snapshot.data!;
+                      print(trafficSapaInfoList);
+                      return Visibility(
+                        visible: widget.provideSapa,
+                        child: InfoContentCard(
+                          children: <Widget>[
+                            SapaInfoHeader(),
+                            for (int i = 0;
+                                i < trafficSapaInfoList.length;
+                                i++) ...{
+                              SapaInfoTile(
+                                name: trafficSapaInfoList[i].name,
+                                direction: trafficSapaInfoList[i].direction,
+                                totalCongestion:
+                                    trafficSapaInfoList[i].totalCongestion,
+                                smallCarCongestion:
+                                    trafficSapaInfoList[i].smallCarCongestion,
+                                largeCarCongestion:
+                                    trafficSapaInfoList[i].largeCarCongestion,
+                              ),
+                            },
+                          ],
+                          title: 'SAPA情報',
+                        ),
+                      );
+                    } else {
+                      return const Center(child: CircularProgressIndicator());
+                    }
                   } else {
-                    return const Center(child: CircularProgressIndicator());
+                    return const Center(child: SizedBox());
                   }
                 }),
           ],

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -8,7 +8,13 @@ import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 
 class TrafficInformationDetailView extends StatefulWidget {
-  const TrafficInformationDetailView({super.key});
+  const TrafficInformationDetailView({
+    super.key,
+    required this.roadId,
+    required this.provideSapa,
+  });
+  final int roadId;
+  final bool provideSapa;
 
   @override
   State<TrafficInformationDetailView> createState() =>

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -1,4 +1,7 @@
 import 'package:fleet_tracker/Controller/TrafficInformation/Detail/traffic_information_detail_controller.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/detail.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/issue.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/sapa_info.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/info_content_card.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_title.dart';
@@ -37,18 +40,18 @@ class _TrafficInformationStateDetailView
       body: SingleChildScrollView(
         child: Column(
           children: <Widget>[
-            FutureBuilder<Map<String, dynamic>?>(
+            FutureBuilder<TrafficDetail?>(
                 future: trafficInformationDetailController
                     .getRoadInfoMap(widget.roadId),
                 builder: (BuildContext context,
-                    AsyncSnapshot<Map<String, dynamic>?> snapshot) {
+                    AsyncSnapshot<TrafficDetail?> snapshot) {
                   if (snapshot.hasData) {
-                    Map<String, dynamic> roadInfoMap = snapshot.data!;
-                    print(roadInfoMap);
+                    TrafficDetail trafficDetail = snapshot.data!;
+                    print(trafficDetail);
                     return JamInfoTitle(
-                      areaName: roadInfoMap['areaName'],
-                      roadName: roadInfoMap['roadName'],
-                      time: roadInfoMap['time'],
+                      areaName: trafficDetail.data.areaName,
+                      roadName: trafficDetail.data.roadName,
+                      time: trafficDetail.summary.updateTimestamp,
                     );
                   } else {
                     return const Center(child: CircularProgressIndicator());
@@ -57,22 +60,24 @@ class _TrafficInformationStateDetailView
             const SizedBox(
               height: 20,
             ),
-            FutureBuilder<List<Map<String, dynamic>>?>(
+            FutureBuilder<List<TrafficIssue>?>(
                 future: trafficInformationDetailController
                     .getJamInfoList(widget.roadId),
                 builder: (BuildContext context,
-                    AsyncSnapshot<List<Map<String, dynamic>>?> snapshot) {
+                    AsyncSnapshot<List<TrafficIssue>?> snapshot) {
                   if (snapshot.hasData) {
-                    List<Map<String, dynamic>> jamInfoList = snapshot.data!;
-                    print(jamInfoList);
+                    List<TrafficIssue> trafficIssueList = snapshot.data!;
+                    print(trafficIssueList);
                     return InfoContentCard(
                       children: <Widget>[
                         for (int i = 0; i < 2; i++) ...{
                           JamInfoPlaceTile(
-                            direction: jamInfoList[i]['direction'],
-                            place: jamInfoList[i]['place'],
-                            type: jamInfoList[i]['type'],
-                            supplementInfo: jamInfoList[i]['supplementInfo'],
+                            direction: trafficIssueList[i].direction,
+                            place: trafficIssueList[i].place,
+                            type: trafficIssueList[i].type,
+                            content: trafficIssueList[i].content,
+                            range: trafficIssueList[i].range,
+                            reason: trafficIssueList[i].reason,
                           ),
                         },
                       ],
@@ -85,18 +90,39 @@ class _TrafficInformationStateDetailView
             const SizedBox(
               height: 20,
             ),
-            Visibility(
-              visible: widget.provideSapa,
-              child: InfoContentCard(
-                children: <Widget>[
-                  SapaInfoHeader(),
-                  for (int i = 0; i < 5; i++) ...{
-                    SapaInfoTile(),
-                  },
-                ],
-                title: 'SAPA情報',
-              ),
-            ),
+            FutureBuilder<List<TrafficSapaInfo>?>(
+                future: trafficInformationDetailController
+                    .getSapaInfoList(widget.roadId),
+                builder: (BuildContext context,
+                    AsyncSnapshot<List<TrafficSapaInfo>?> snapshot) {
+                  if (snapshot.hasData) {
+                    List<TrafficSapaInfo> trafficSapaInfoList = snapshot.data!;
+                    //if
+                    return Visibility(
+                      visible: widget.provideSapa,
+                      child: InfoContentCard(
+                        children: <Widget>[
+                          SapaInfoHeader(),
+                          for (int i = 0; i < 5; i++) ...{
+                            SapaInfoTile(
+                              name: trafficSapaInfoList[i].name,
+                              direction: trafficSapaInfoList[i].direction,
+                              totalCongestion:
+                                  trafficSapaInfoList[i].totalCongestion,
+                              smallCarCongestion:
+                                  trafficSapaInfoList[i].smallCarCongestion,
+                              largeCarCongestion:
+                                  trafficSapaInfoList[i].largeCarCongestion,
+                            ),
+                          },
+                        ],
+                        title: 'SAPA情報',
+                      ),
+                    );
+                  } else {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                }),
           ],
         ),
       ),

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -34,7 +34,9 @@ class _TrafficInformationStateDetailView
             InfoContentCard(
               children: <Widget>[
                 for (int i = 0; i < 2; i++) ...{
-                  JamInfoPlaceTile(),
+                  JamInfoPlaceTile(
+                    roadId: 7,
+                  ),
                 },
               ],
               title: '渋滞情報',

--- a/lib/View/TrafficInformation/traffic_information_top_view.dart
+++ b/lib/View/TrafficInformation/traffic_information_top_view.dart
@@ -23,7 +23,7 @@ class _TrafficInformationStateTopViewState
     return Scaffold(
       appBar: CustomAppBar(),
       body: FutureBuilder<List<Map<String, dynamic>>?>(
-        future: trafficInformationTopController.getPrefectureNameMap(),
+        future: trafficInformationTopController.getPrefectureInfoList(),
         builder: (BuildContext context,
             AsyncSnapshot<List<Map<String, dynamic>>?> snapshot) {
           if (snapshot.hasData) {

--- a/lib/View/TrafficInformation/traffic_information_top_view.dart
+++ b/lib/View/TrafficInformation/traffic_information_top_view.dart
@@ -1,3 +1,4 @@
+import 'package:fleet_tracker/Controller/TrafficInformation/traffic_information_top_controller.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
 import 'package:flutter/material.dart';
@@ -12,158 +13,39 @@ class TrafficInformationTopView extends StatefulWidget {
 
 class _TrafficInformationStateTopViewState
     extends State<TrafficInformationTopView> {
-  Map<String, List<String>> prefectureNameMap = {
-    '北海道': [
-      '深川留萌道',
-      '道央道',
-      '札樽道',
-      '後志道',
-      '道東道',
-      '日高道',
-    ],
-    '東北': [
-      '百石道路',
-      '青森道',
-      '東北道',
-      '八戸道',
-      '釜石道',
-      '秋田道',
-      '日本海東北道',
-      '仙台北部道路',
-      '仙台東部道路',
-      '仙台南部道路',
-      '東北中央道',
-      '湯沢横手道路',
-      '山形道',
-      '常磐道',
-      '磐越道',
-    ],
-    '北陸・信越': [
-      '日本海東北道',
-      '磐越道',
-      '関越道',
-      '上信越道',
-      '北陸道',
-      '東海北陸道',
-      '安房峠道路',
-      '長野道',
-      '中央道',
-    ],
-    '関東': [
-      '常磐道',
-      '東北道',
-      '北関東道',
-      '関越道',
-      '上信越道',
-      '東水戸道路',
-      '東北道',
-      '圏央道',
-      '中央道',
-      '京葉道路',
-      '東京外環道',
-      '中部横断道',
-      '東富士五湖道路',
-      '第三京浜',
-      '東関東道',
-      '館山道',
-      '富津館山道路',
-      '東京湾アクアライン',
-      '東名',
-      '小田原厚木道路',
-      '西湘バイパス',
-      '横浜横須賀道路',
-    ],
-    '東海': [
-      '長野道',
-      '安房峠道路',
-      '東海北陸道',
-      '中央道',
-      '中部横断道',
-      '名神',
-      '名二環',
-      '新東名',
-      '東名',
-      '伊勢湾岸道',
-      '東名阪道',
-      '伊勢道',
-      '紀勢道',
-    ],
-    '関西': [
-      '名神',
-      '新名神',
-      '京都縦貫道',
-      '京滋バイパス',
-      '京奈和道',
-      '舞鶴若狭道',
-      '中国道',
-      '播磨道',
-      '三陽道',
-      '第二京阪道路',
-      '第二阪奈道路',
-      '第二神明道路',
-      '神戸淡路鳴門道',
-      '近畿道',
-      '西名阪道',
-      '堺泉北道',
-      '南阪奈道路',
-      '関空橋',
-      '阪和道',
-      '湯浅御坊道路',
-    ],
-    '中国': [
-      '山陰道',
-      '松江道',
-      '米子道',
-      '中国道',
-      '浜田道',
-      '岡山道',
-      '広島道',
-      '瀬戸中央道',
-      '西瀬戸道',
-      '山陽道',
-    ],
-    '四国': [
-      '瀬戸中央道',
-      '西瀬戸道',
-      '高松道',
-      '神戸淡路鳴門道',
-      '徳島道',
-      '徳島南部道',
-      '高知道',
-      '松山道',
-      '今治小松道',
-    ],
-    '九州・沖縄': [
-      '九州道',
-      '東九州道',
-      '日出バイパス',
-      '大分道',
-      '長崎道',
-      '長崎バイパス',
-      '西九州道',
-      '南九州道',
-      '宮崎道',
-      '沖縄道',
-    ],
-  };
   String imageUrl = 'https://www.c-ihighway.jp/smp/img/MAP/hokkaido.png';
   int count = 50;
+  TrafficInformationTopController trafficInformationTopController =
+      TrafficInformationTopController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(),
-      body: ListView.builder(
-        itemCount: prefectureNameMap.length,
-        itemBuilder: (BuildContext context, int index) {
-          String prefectureName = prefectureNameMap.keys.elementAt(index);
-          List<String> prefecturalRoadList = prefectureNameMap[prefectureName]!;
-          return TrafficInformationTileCell(
-            imageUrl: imageUrl,
-            count: count,
-            prefectureName: prefectureName,
-            prefecturalRoadList: prefecturalRoadList,
-          );
+      body: FutureBuilder<List<Map<String, dynamic>>?>(
+        future: trafficInformationTopController.getPrefectureNameMap(),
+        builder: (BuildContext context,
+            AsyncSnapshot<List<Map<String, dynamic>>?> snapshot) {
+          if (snapshot.hasData) {
+            List<Map<String, dynamic>> prefectureInfoList = snapshot.data!;
+            return ListView.builder(
+              itemCount: prefectureInfoList.length,
+              itemBuilder: (BuildContext context, int index) {
+                String prefectureName = prefectureInfoList[index]['name'];
+                List<Map> prefecturalRoadList =
+                    prefectureInfoList[index]['roads'];
+
+                return TrafficInformationTileCell(
+                  imageUrl: imageUrl,
+                  count: prefectureInfoList[index]['totalIssues'],
+                  prefectureName: prefectureName,
+                  prefecturalRoadList: prefecturalRoadList,
+                );
+              },
+            );
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
         },
       ),
     );

--- a/lib/View/TrafficInformation/traffic_information_top_view.dart
+++ b/lib/View/TrafficInformation/traffic_information_top_view.dart
@@ -1,4 +1,6 @@
 import 'package:fleet_tracker/Controller/TrafficInformation/traffic_information_top_controller.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/area.dart';
+import 'package:fleet_tracker/Model/Entity/Traffic/road.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/TrafficInformation/traffic_information_accordion_tile.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
 import 'package:flutter/material.dart';
@@ -22,22 +24,22 @@ class _TrafficInformationStateTopViewState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(),
-      body: FutureBuilder<List<Map<String, dynamic>>?>(
+      body: FutureBuilder<List<TrafficArea>?>(
         future: trafficInformationTopController.getPrefectureInfoList(),
-        builder: (BuildContext context,
-            AsyncSnapshot<List<Map<String, dynamic>>?> snapshot) {
+        builder:
+            (BuildContext context, AsyncSnapshot<List<TrafficArea>?> snapshot) {
           if (snapshot.hasData) {
-            List<Map<String, dynamic>> prefectureInfoList = snapshot.data!;
+            List<TrafficArea> prefectureInfoList = snapshot.data!;
             return ListView.builder(
               itemCount: prefectureInfoList.length,
               itemBuilder: (BuildContext context, int index) {
-                String prefectureName = prefectureInfoList[index]['name'];
-                List<Map> prefecturalRoadList =
-                    prefectureInfoList[index]['roads'];
+                String prefectureName = prefectureInfoList[index].name;
+                List<TrafficRoad> prefecturalRoadList =
+                    prefectureInfoList[index].roads;
 
                 return TrafficInformationTileCell(
                   imageUrl: imageUrl,
-                  count: prefectureInfoList[index]['totalIssues'],
+                  count: prefectureInfoList[index].totalIssues,
                   prefectureName: prefectureName,
                   prefecturalRoadList: prefecturalRoadList,
                 );

--- a/lib/View/TrafficInformation/traffic_information_top_view.dart
+++ b/lib/View/TrafficInformation/traffic_information_top_view.dart
@@ -16,7 +16,6 @@ class TrafficInformationTopView extends StatefulWidget {
 class _TrafficInformationStateTopViewState
     extends State<TrafficInformationTopView> {
   String imageUrl = 'https://www.c-ihighway.jp/smp/img/MAP/hokkaido.png';
-  int count = 50;
   TrafficInformationTopController trafficInformationTopController =
       TrafficInformationTopController();
 
@@ -25,7 +24,7 @@ class _TrafficInformationStateTopViewState
     return Scaffold(
       appBar: CustomAppBar(),
       body: FutureBuilder<List<TrafficArea>?>(
-        future: trafficInformationTopController.getPrefectureInfoList(),
+        future: trafficInformationTopController.getTraffiiAreatList(),
         builder:
             (BuildContext context, AsyncSnapshot<List<TrafficArea>?> snapshot) {
           if (snapshot.hasData) {


### PR DESCRIPTION
## 概要
交通情報ページと交通情報詳細ページのController作成とそれに伴ったviewの修正。

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- TrafficInformationTopController作成
- getTraffiiAreatList作成

- TrafficInformationDetailController作成
- getTrafficDetail作成
- getTrafficIssueList作成
- getTrafficSapaInfoList作成
- formatDateTime作成

- congestion_type_enum.dart作成

- 交通情報ページと交通情報詳細ページのview修正

sapa情報カードについて、provideSapaがfalseのときは呼び出されないようになっていますが、現在provideSapaがtrueでも値が空の配列で帰ってくるので東海道を選択したときだけタイトルとヘッダーのみのカードが表示されます。

## スクリーンショット
このセクションでは、変更・修正された画面のスクリーンショットを添付してください。
![スクリーンショット (481)](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/109326780/e0bb8945-f016-4504-b0a7-4372eebf9444)
![スクリーンショット (482)](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/109326780/3fb5a8be-6e12-4c09-b83a-697640ffba8c)
## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda