### PR TITLE
fix: お気に入り倉庫から遅延状態の登録とコメントを出来ないように修正

### DIFF
--- a/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
+++ b/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
@@ -259,7 +259,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
                                         context: context,
-                                        title: '倉庫検索から操作はできません',
+                                        title: 'エリア外から登録はできません',
                                         content: Assets
                                             .images.icons.errorDialogIcon
                                             .image(),
@@ -301,7 +301,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
                                         context: context,
-                                        title: '倉庫検索から操作はできません',
+                                        title: 'エリア外から登録はできません',
                                         content: Assets
                                             .images.icons.errorDialogIcon
                                             .image(),
@@ -343,7 +343,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
                                         context: context,
-                                        title: '倉庫検索から操作はできません',
+                                        title: 'エリア外から登録はできません',
                                         content: Assets
                                             .images.icons.errorDialogIcon
                                             .image(),
@@ -385,7 +385,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
                                         context: context,
-                                        title: '倉庫検索から操作はできません',
+                                        title: 'エリア外から登録はできません',
                                         content: Assets
                                             .images.icons.errorDialogIcon
                                             .image(),
@@ -429,7 +429,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
                                         context: context,
-                                        title: '倉庫検索から操作はできません',
+                                        title: 'エリア外から登録はできません',
                                         content: Assets
                                             .images.icons.errorDialogIcon
                                             .image(),

--- a/lib/View/Home/home_view.dart
+++ b/lib/View/Home/home_view.dart
@@ -383,6 +383,10 @@ class _HomeViewState extends State<HomeView> {
                                       warehouseAreaId: data.warehouseAreaId,
                                       warehouseName: data.warehouseName,
                                       warehouseId: data.warehouseId,
+                                      enableAction: _data.warehouses!.any(
+                                          (element) =>
+                                              element.warehouseId ==
+                                              data.warehouseId),
 
                                       /// 後ほど
                                       traficstateCountList:
@@ -392,8 +396,12 @@ class _HomeViewState extends State<HomeView> {
                                       toWarehousePage: () {
                                         WarehouseDetailRoute(
                                           $extra: data,
-                                          functionType:
-                                              FunctionTypeEnum.home.name,
+                                          functionType: _data.warehouses!.any(
+                                                  (element) =>
+                                                      element.warehouseId ==
+                                                      data.warehouseId)
+                                              ? FunctionTypeEnum.home.name
+                                              : FunctionTypeEnum.search.name,
                                         ).push(context);
                                       },
                                     ),
@@ -952,6 +960,7 @@ class _HomeViewState extends State<HomeView> {
                                           warehouseAreaId: data.warehouseAreaId,
                                           warehouseName: data.warehouseName,
                                           warehouseId: data.warehouseId,
+                                          enableAction: false,
 
                                           /// 後ほど
                                           traficstateCountList:
@@ -962,7 +971,7 @@ class _HomeViewState extends State<HomeView> {
                                             WarehouseDetailRoute(
                                               $extra: data,
                                               functionType:
-                                                  FunctionTypeEnum.home.name,
+                                                  FunctionTypeEnum.search.name,
                                             ).push(context);
                                           },
                                         ),


### PR DESCRIPTION
## 概要
お気に入り倉庫から遅延状態の登録とコメントを出来ないように修正。

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 引数enableActionにエリア外のお気に入り倉庫はfalseを設定
- 引数functionTypeにエリア外のお気に入り倉庫はFunctionTypeEnum.search.nameを設定
- エラーダイアログのタイトルを'エリア外から登録はできません'に変更

## スクリーンショット
このセクションでは、変更・修正された画面のスクリーンショットを添付してください。
![スクリーンショット (485)](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/109326780/ce031ca2-7c77-43b2-86cb-657d5940d220)

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda
![スクリーンショット (486)](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/109326780/84ca00e4-e2eb-4fb7-b2a0-4c8f5b133359)
