### PR TITLE
ダイアログ改修

### DIFF
--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -29,7 +29,7 @@ import '../Service/API/Original/warehouse_service.dart';
 import '../Service/Log/log_service.dart';
 import '../Service/Package/BackgroundLocator/background_locator_service.dart';
 import '../Service/Package/LocalNotification/local_notifications_service.dart';
-import '../View/Component/CustomWidget/Dialog/error_dialog.dart';
+import '../View/Component/CustomWidget/Dialog/custom_dialog.dart';
 
 class TopLoadingController {
   FirebaseAuthenticationService get authenticationService =>
@@ -57,7 +57,7 @@ class TopLoadingController {
     bool releaseValue = RemoteConfigService().getBool(RemoteConfigKeys.release);
     if (!releaseValue) {
       final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
+      CustomDialog().showCustomDialog(
         context: context,
         title: 'メンテナンス中です...',
         content: Assets.images.icons.errorDialogIcon.image(),
@@ -73,7 +73,7 @@ class TopLoadingController {
     notificationPermissionStatus = await checkNotificationPermission();
     if (!notificationPermissionStatus) {
       final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
+      CustomDialog().showCustomDialog(
         context: context,
         title: 'エラー',
         buttonText: Strings.BACK_BUTTON_TEXT,
@@ -166,7 +166,7 @@ class TopLoadingController {
     locationPermissionStatus = await checkLocationPermission();
     if (!locationPermissionStatus) {
       final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
+      CustomDialog().showCustomDialog(
         context: context,
         title: 'エラー',
         buttonText: Strings.BACK_BUTTON_TEXT,
@@ -215,7 +215,7 @@ class TopLoadingController {
 
     if (status.isDenied || status.isRestricted || status.isPermanentlyDenied) {
       final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
+      CustomDialog().showCustomDialog(
         context: context,
         title: '通知を利用します',
         content: const Icon(Icons.info_outline_rounded, color: Colors.blue),
@@ -252,7 +252,7 @@ class TopLoadingController {
 
     if (status.isDenied || status.isRestricted || status.isPermanentlyDenied) {
       final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
+      CustomDialog().showCustomDialog(
         context: context,
         title: '位置情報を利用します',
         content: const Icon(Icons.info_outline_rounded, color: Colors.blue),

--- a/lib/View/Component/CustomWidget/Dialog/custom_dialog.dart
+++ b/lib/View/Component/CustomWidget/Dialog/custom_dialog.dart
@@ -3,16 +3,18 @@ import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
 import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 
-class ErrorDialog {
-  showErrorDialog({
+class CustomDialog {
+  showCustomDialog({
     required BuildContext context,
     required String title,
     required Widget content,
     required String detail,
     String buttonText = '閉じる',
+    String rejectButtonTest = 'キャンセル',
     Function? buttonAction,
     bool barrierDismissible = false,
     bool isShowButton = true,
+    bool isShowRejectButton = false,
   }) {
     showDialog(
       context: context,
@@ -119,6 +121,26 @@ class ErrorDialog {
                                         ).pop();
                                       },
                               ),
+                            ),
+                          ),
+                        ),
+                      ],
+                      if (isShowRejectButton) ...[
+                        Expanded(
+                          flex: 1,
+                          child: SizedBox(
+                            width: 200,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 5),
+                              child: CustomButton(
+                                  primaryColor: ColorName.textBlack,
+                                  text: rejectButtonTest,
+                                  onTap: () {
+                                    Navigator.of(
+                                      context,
+                                      rootNavigator: true,
+                                    ).pop();
+                                  }),
                             ),
                           ),
                         ),

--- a/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
+++ b/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
@@ -6,7 +6,7 @@ import 'package:fleet_tracker/Controller/UserInput/user_input_top_controller.dar
 import 'package:fleet_tracker/Model/Entity/delay_information.dart';
 import 'package:fleet_tracker/Model/Entity/delay_time_detail.dart';
 import 'package:fleet_tracker/Service/API/Original/delay_service.dart';
-import 'package:fleet_tracker/View/Component/CustomWidget/Dialog/error_dialog.dart';
+import 'package:fleet_tracker/View/Component/CustomWidget/Dialog/custom_dialog.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/UserInput/user_input_circle_cell.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/circular_progress_indicator_cell.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
@@ -259,7 +259,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 text: Strings.STATE_NORMAL_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
-                                    ErrorDialog().showErrorDialog(
+                                    CustomDialog().showCustomDialog(
                                         context: context,
                                         title: 'エリア外から登録はできません',
                                         content: Assets
@@ -301,7 +301,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 text: Strings.STATE_PAUSE_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
-                                    ErrorDialog().showErrorDialog(
+                                    CustomDialog().showCustomDialog(
                                         context: context,
                                         title: 'エリア外から登録はできません',
                                         content: Assets
@@ -343,7 +343,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 text: Strings.STATE_HALF_HOUR_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
-                                    ErrorDialog().showErrorDialog(
+                                    CustomDialog().showCustomDialog(
                                         context: context,
                                         title: 'エリア外から登録はできません',
                                         content: Assets
@@ -385,7 +385,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 text: Strings.STATE_AN_HOUR_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
-                                    ErrorDialog().showErrorDialog(
+                                    CustomDialog().showCustomDialog(
                                         context: context,
                                         title: 'エリア外から登録はできません',
                                         content: Assets
@@ -429,7 +429,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 text: Strings.STATE_IMPOSSIBLE_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
-                                    ErrorDialog().showErrorDialog(
+                                    CustomDialog().showCustomDialog(
                                         context: context,
                                         title: 'エリア外から登録はできません',
                                         content: Assets

--- a/lib/View/Setting/setting_top_view.dart
+++ b/lib/View/Setting/setting_top_view.dart
@@ -2,7 +2,7 @@ import 'package:fleet_tracker/Constants/strings.dart';
 import 'package:fleet_tracker/Controller/Setting/setting_top_controller.dart';
 import 'package:fleet_tracker/Model/Data/user_data.dart';
 import 'package:fleet_tracker/Service/Log/log_service.dart';
-import 'package:fleet_tracker/View/Component/CustomWidget/Dialog/error_dialog.dart';
+import 'package:fleet_tracker/View/Component/CustomWidget/Dialog/custom_dialog.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/Setting/setting_tile_cell.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/circular_progress_indicator_cell.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_appbar.dart';
@@ -74,7 +74,7 @@ class _SettingTopViewState extends State<SettingTopView> {
                     title: '位置情報取得',
                     detail: snapshot.data == true ? 'ON' : 'OFF',
                     onTap: () {
-                      ErrorDialog().showErrorDialog(
+                      CustomDialog().showCustomDialog(
                         context: context,
                         title: '位置情報取得',
                         content: Icon(
@@ -94,6 +94,8 @@ class _SettingTopViewState extends State<SettingTopView> {
                             rootNavigator: true,
                           ).pop();
                         },
+                        isShowRejectButton: true,
+                        barrierDismissible: true,
                         buttonText: '変更',
                       );
                     },


### PR DESCRIPTION
## 概要
error_dialogをcustom_dialogに変更し、変更をを拒否するボタンを追加

## 変更点

- error_dialogをcustom_dialogに名称変更
- custom_dialogに変更拒否ボタンを追加
- 設定画面において、位置情報取得許可ダイアログがBlurされたときにダイアログを閉じるように変更

## スクリーンショット

![IMG_3059](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/97656717/e917c709-b8d5-417c-9806-37f7f6cdf5f7)

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda