### PR TITLE
【リジェクト対策】パーミッション拒否時にもアプリを進めるように

### DIFF
--- a/lib/Controller/Home/home_controller.dart
+++ b/lib/Controller/Home/home_controller.dart
@@ -13,6 +13,7 @@ import 'package:fleet_tracker/Service/Package/SharedPreferences/shared_preferenc
 import 'package:intl/intl.dart';
 
 import 'package:geocoding/geocoding.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../../Model/Entity/Warehouse/warehouse.dart';
 import '../../Service/API/Original/warehouse_service.dart';
@@ -143,5 +144,13 @@ class HomeController {
       }
     }
     return favoriteWarehouseList;
+  }
+
+  Future<PermissionStatus> getLocationPermission() async {
+    return Permission.location.status;
+  }
+
+  Future<void> requestLocationPermission() async {
+    openAppSettings();
   }
 }

--- a/lib/Controller/Setting/setting_top_controller.dart
+++ b/lib/Controller/Setting/setting_top_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:in_app_review/in_app_review.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../Constants/Enum/shared_preferences_keys_enum.dart';
 import '../../Model/Entity/user.dart';
@@ -121,13 +122,16 @@ class SettingTopController {
   }
 
   /// バックグラウンドロケーションのステータス
-  Future<bool> getBackgroundLocatorStatus() async {
-    return await BackgroundLocatorService().isRunning();
+  Future<bool?> getBackgroundLocatorStatus() async {
+    if (await Permission.location.isGranted) {
+      return await BackgroundLocatorService().isRunning();
+    }
+    return null;
   }
 
   /// バックグラウンドロケーションのステータス変更
   Future<void> changeBackgroundLocatorStatus() async {
-    if (await getBackgroundLocatorStatus()) {
+    if (await getBackgroundLocatorStatus() ?? false) {
       await BackgroundLocatorService().stop();
     } else {
       await BackgroundLocatorService().start();

--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -72,24 +72,6 @@ class TopLoadingController {
 
     notificationPermissionStatus = await checkNotificationPermission();
 
-    if (!notificationPermissionStatus) {
-      final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
-        context: context,
-        title: 'エラー',
-        buttonText: '設定を開く',
-        content: Assets.images.icons.errorDialogIcon.image(
-          color: Colors.red,
-        ),
-        detail: '通知の許可が必要です',
-        buttonAction: () {
-          openAppSettings();
-          return completer.future;
-        },
-      );
-      return completer.future;
-    }
-
     Log.echo('SharedPreferences Initialize', symbol: '🔍');
 
     /// SharedPreferences Initialize
@@ -168,24 +150,6 @@ class TopLoadingController {
     UserData().setData(data: userInfo);
 
     locationPermissionStatus = await checkLocationPermission();
-
-    if (!locationPermissionStatus) {
-      final completer = Completer<void>();
-      ErrorDialog().showErrorDialog(
-        context: context,
-        title: 'エラー',
-        buttonText: '設定を開く',
-        content: Assets.images.icons.errorDialogIcon.image(
-          color: Colors.red,
-        ),
-        detail: '位置情報の許可が必要です',
-        buttonAction: () {
-          openAppSettings();
-          return completer.future;
-        },
-      );
-      return completer.future;
-    }
 
     /// 位置情報を取得
     Location location = LocationData().getData();

--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -71,17 +71,21 @@ class TopLoadingController {
     await LocalNotificationsService().initialize();
 
     notificationPermissionStatus = await checkNotificationPermission();
+
     if (!notificationPermissionStatus) {
       final completer = Completer<void>();
       ErrorDialog().showErrorDialog(
         context: context,
         title: 'エラー',
-        buttonText: Strings.BACK_BUTTON_TEXT,
+        buttonText: '設定を開く',
         content: Assets.images.icons.errorDialogIcon.image(
           color: Colors.red,
         ),
         detail: '通知の許可が必要です',
-        isShowButton: false,
+        buttonAction: () {
+          openAppSettings();
+          return completer.future;
+        },
       );
       return completer.future;
     }
@@ -164,17 +168,21 @@ class TopLoadingController {
     UserData().setData(data: userInfo);
 
     locationPermissionStatus = await checkLocationPermission();
+
     if (!locationPermissionStatus) {
       final completer = Completer<void>();
       ErrorDialog().showErrorDialog(
         context: context,
         title: 'エラー',
-        buttonText: Strings.BACK_BUTTON_TEXT,
+        buttonText: '設定を開く',
         content: Assets.images.icons.errorDialogIcon.image(
           color: Colors.red,
         ),
         detail: '位置情報の許可が必要です',
-        isShowButton: false,
+        buttonAction: () {
+          openAppSettings();
+          return completer.future;
+        },
       );
       return completer.future;
     }

--- a/lib/Model/Data/location_data.dart
+++ b/lib/Model/Data/location_data.dart
@@ -17,7 +17,12 @@ class LocationData extends ChangeNotifier {
 
   /// getter
   Location getData() {
-    return _data!;
+    return _data ??
+        Location(
+          lat: 43.0,
+          lng: 141.0,
+          time: DateTime.now(),
+        );
   }
 
   /// setter

--- a/lib/View/Home/home_view.dart
+++ b/lib/View/Home/home_view.dart
@@ -13,7 +13,9 @@ import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:permission_handler/permission_handler.dart';
 import '../../Model/Data/Warehouse/search_info_data.dart';
 import '../../Route/router.dart';
 import '../Component/CustomWidget/UserInput/user_input_cell.dart';
@@ -30,8 +32,21 @@ class _HomeViewState extends State<HomeView> {
   HomeController controller = HomeController();
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
+    Future(() async {
+      if (await controller.getLocationPermission() !=
+          PermissionStatus.granted) {
+        Fluttertoast.showToast(
+          msg: '位置情報の許可が必要です！',
+          toastLength: Toast.LENGTH_SHORT,
+          gravity: ToastGravity.CENTER,
+          timeInSecForIosWeb: 3,
+          backgroundColor: Colors.red,
+          textColor: Colors.white,
+          fontSize: 16.0,
+        );
+      }
+    });
   }
 
   @override

--- a/lib/View/Setting/setting_top_view.dart
+++ b/lib/View/Setting/setting_top_view.dart
@@ -11,6 +11,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../Route/router.dart';
@@ -72,10 +73,17 @@ class _SettingTopViewState extends State<SettingTopView> {
                     if (snapshot.connectionState != ConnectionState.done) {
                       return const CircularProgressIndicator();
                     }
+
                     return SettingTileCell().withDetail(
                       title: '位置情報取得',
                       detail: snapshot.data == true ? 'ON' : 'OFF',
                       onTap: () {
+                        if (snapshot.data == null) {
+                          Fluttertoast.showToast(
+                            msg: '位置情報の取得が許可されていません。',
+                          );
+                          return;
+                        }
                         ErrorDialog().showErrorDialog(
                           context: context,
                           title: '位置情報取得',

--- a/lib/View/Setting/setting_top_view.dart
+++ b/lib/View/Setting/setting_top_view.dart
@@ -11,6 +11,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../../Route/router.dart';
 import '../Component/CustomWidget/Modal/rename_modal.dart';
@@ -37,167 +38,176 @@ class _SettingTopViewState extends State<SettingTopView> {
       body: FutureBuilder(
         future: controller.init(),
         builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-          return Column(
-            children: [
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: CustomText(
-                    text: Strings.SETTING_ACOUNT_INFO,
-                    fontSize: 14,
+          return SingleChildScrollView(
+            child: Column(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: CustomText(
+                      text: Strings.SETTING_ACOUNT_INFO,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
-              ),
-              SettingTileCell().withDetail(
-                title: 'ユーザー名',
-                detail: UserData().getData().name ?? "",
-                onTap: () async {
-                  // コメント投稿をする際の表示名を変更できる項目
-                  Log.echo('名前変更');
-                  await controller.showReNameModal(
-                      context: context,
-                      size: size,
-                      setState: () {
-                        setState(() {});
-                      });
-                  setState(() {});
-                },
-              ),
-              FutureBuilder(
-                future: controller.getBackgroundLocatorStatus(),
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState != ConnectionState.done) {
-                    return const CircularProgressIndicator();
-                  }
-                  return SettingTileCell().withDetail(
-                    title: '位置情報取得',
-                    detail: snapshot.data == true ? 'ON' : 'OFF',
-                    onTap: () {
-                      ErrorDialog().showErrorDialog(
+                SettingTileCell().withDetail(
+                  title: 'ユーザー名',
+                  detail: UserData().getData().name ?? "",
+                  onTap: () async {
+                    // コメント投稿をする際の表示名を変更できる項目
+                    Log.echo('名前変更');
+                    await controller.showReNameModal(
                         context: context,
-                        title: '位置情報取得',
-                        content: Icon(
-                          snapshot.data == true
-                              ? Icons.location_off
-                              : Icons.location_on,
-                          size: 50,
-                        ),
-                        detail: snapshot.data == true
-                            ? '位置情報取得を停止しますか？'
-                            : '位置情報取得を開始しますか？',
-                        buttonAction: () async {
-                          await controller.changeBackgroundLocatorStatus();
+                        size: size,
+                        setState: () {
                           setState(() {});
-                          Navigator.of(
-                            context,
-                            rootNavigator: true,
-                          ).pop();
-                        },
-                        buttonText: '変更',
-                      );
-                    },
-                  );
-                },
-              ),
-              if (kDebugMode)
-                SettingTileCell().common(
-                  '開発用設定',
-                  onTap: () {
-                    Log.echo('開発ボタン');
-                    controller.showDebugModal(context: context, size: size);
+                        });
+                    setState(() {});
                   },
                 ),
-              // const Padding(
-              //   padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-              //   child: Align(
-              //     alignment: Alignment.centerLeft,
-              //     child: CustomText(
-              //       text: Strings.SETTING_NOTIFICATION,
-              //       fontSize: 14,
-              //     ),
-              //   ),
-              // ),
-              // SettingTileCell().withSwitch(
-              //   subTitle: 'エリア通知',
-              //   cellAction: (bool) {
-              //     // エリア内に入る or エリアから出るで通知
-              //     controller.areaSwitchValue = bool;
-              //     controller.actionAreaSwitch(value: bool);
-              //     setState(() {});
-              //   },
-              //   switchValue: controller.areaSwitchValue ?? true,
-              // ),
-              // SettingTileCell().withSwitch(
-              //   subTitle: '遅延情報通知',
-              //   cellAction: (bool) {
-              //     // 渋滞情報に変更があったら通知
-              //     controller.delaySwitchValue = bool;
-              //     controller.actionDelaySwitch(value: bool);
-              //     setState(() {});
-              //   },
-              //   switchValue: controller.delaySwitchValue ?? true,
-              // ),
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: CustomText(
-                    text: Strings.SETTING_OTHER,
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-              SettingTileCell().common(
-                'チュートリアル',
-                onTap: () {
-                  TutorialRoute().push(context);
-                },
-              ),
-              SettingTileCell().common(
-                '使い方',
-                onTap: () {
-                  const HowToUseRoute().push(context);
-                },
-              ),
-              SettingTileCell().common(
-                'お問い合わせ',
-                onTap: () {
-                  // お問い合わせを送信するページ
-                  controller.openInquiry();
-                },
-              ),
-              SettingTileCell().common(
-                'アプリをレビューする',
-                onTap: () {
-                  // ストアページのレビューへ遷移
-                  controller.openReview();
-                },
-              ),
-              SettingTileCell().common(
-                'プライバシーポリシー',
-                onTap: () {
-                  // プライバシーポリシー
-                  controller.openPrivacyPolicy();
-                },
-              ),
-              SettingTileCell().common(
-                'ライセンス',
-                onTap: () {
-                  // ライセンスを表示
-                  const LicenseRoute().push(context);
-                },
-              ),
-              FutureBuilder(
-                  future: controller.getAppVersion(),
+                FutureBuilder(
+                  future: controller.getBackgroundLocatorStatus(),
                   builder: (context, snapshot) {
                     if (snapshot.connectionState != ConnectionState.done) {
                       return const CircularProgressIndicator();
                     }
                     return SettingTileCell().withDetail(
-                        title: 'アプリバージョン', detail: '${snapshot.data}');
-                  }),
-            ],
+                      title: '位置情報取得',
+                      detail: snapshot.data == true ? 'ON' : 'OFF',
+                      onTap: () {
+                        ErrorDialog().showErrorDialog(
+                          context: context,
+                          title: '位置情報取得',
+                          content: Icon(
+                            snapshot.data == true
+                                ? Icons.location_off
+                                : Icons.location_on,
+                            size: 50,
+                          ),
+                          detail: snapshot.data == true
+                              ? '位置情報取得を停止しますか？'
+                              : '位置情報取得を開始しますか？',
+                          buttonAction: () async {
+                            await controller.changeBackgroundLocatorStatus();
+                            setState(() {});
+                            Navigator.of(
+                              context,
+                              rootNavigator: true,
+                            ).pop();
+                          },
+                          buttonText: '変更',
+                        );
+                      },
+                    );
+                  },
+                ),
+                if (kDebugMode)
+                  SettingTileCell().common(
+                    '開発用設定',
+                    onTap: () {
+                      Log.echo('開発ボタン');
+                      controller.showDebugModal(context: context, size: size);
+                    },
+                  ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: CustomText(
+                      text: Strings.SETTING_NOTIFICATION,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                SettingTileCell().common(
+                  '端末の設定を開く',
+                  onTap: () {
+                    // 通知設定画面へ遷移
+                    openAppSettings();
+                  },
+                ),
+                // SettingTileCell().withSwitch(
+                //   subTitle: 'エリア通知',
+                //   cellAction: (bool) {
+                //     // エリア内に入る or エリアから出るで通知
+                //     controller.areaSwitchValue = bool;
+                //     controller.actionAreaSwitch(value: bool);
+                //     setState(() {});
+                //   },
+                //   switchValue: controller.areaSwitchValue ?? true,
+                // ),
+                // SettingTileCell().withSwitch(
+                //   subTitle: '遅延情報通知',
+                //   cellAction: (bool) {
+                //     // 渋滞情報に変更があったら通知
+                //     controller.delaySwitchValue = bool;
+                //     controller.actionDelaySwitch(value: bool);
+                //     setState(() {});
+                //   },
+                //   switchValue: controller.delaySwitchValue ?? true,
+                // ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: CustomText(
+                      text: Strings.SETTING_OTHER,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                SettingTileCell().common(
+                  'チュートリアル',
+                  onTap: () {
+                    TutorialRoute().push(context);
+                  },
+                ),
+                SettingTileCell().common(
+                  '使い方',
+                  onTap: () {
+                    const HowToUseRoute().push(context);
+                  },
+                ),
+                SettingTileCell().common(
+                  'お問い合わせ',
+                  onTap: () {
+                    // お問い合わせを送信するページ
+                    controller.openInquiry();
+                  },
+                ),
+                SettingTileCell().common(
+                  'アプリをレビューする',
+                  onTap: () {
+                    // ストアページのレビューへ遷移
+                    controller.openReview();
+                  },
+                ),
+                SettingTileCell().common(
+                  'プライバシーポリシー',
+                  onTap: () {
+                    // プライバシーポリシー
+                    controller.openPrivacyPolicy();
+                  },
+                ),
+                SettingTileCell().common(
+                  'ライセンス',
+                  onTap: () {
+                    // ライセンスを表示
+                    const LicenseRoute().push(context);
+                  },
+                ),
+                FutureBuilder(
+                    future: controller.getAppVersion(),
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState != ConnectionState.done) {
+                        return const CircularProgressIndicator();
+                      }
+                      return SettingTileCell().withDetail(
+                          title: 'アプリバージョン', detail: '${snapshot.data}');
+                    }),
+              ],
+            ),
           );
         },
       ),


### PR DESCRIPTION
## 概要
パーミッションが認可されないときに進めなかったことがリジェクトの原因として、対策を行いました

## 変更点
- TopLoadingでエラーダイアログによる強制STOPを廃止
- Locationが許可されていないときは、デフォルト値を設定
- 設定タブで端末設定を呼び出せるボタン

## スクリーンショット
discord