### PR TITLE
add: 色々細かいところのview調整

### DIFF
--- a/lib/Constants/Enum/warehouse_area_enum.dart
+++ b/lib/Constants/Enum/warehouse_area_enum.dart
@@ -1,0 +1,91 @@
+enum WarehouseAreaEnum {
+  hokkaido,
+  touhoku,
+  saitama,
+  tokyo,
+  chiba,
+  kanagawa,
+  chubu,
+  kinki,
+  chugoku,
+  shikoku,
+  kyushu,
+  okinawa,
+}
+
+class WarehouseAreaType {
+  late WarehouseAreaEnum type;
+  WarehouseAreaType(int rowType) {
+    switch (rowType) {
+      case 1:
+        type = WarehouseAreaEnum.hokkaido;
+        break;
+      case 2:
+        type = WarehouseAreaEnum.touhoku;
+        break;
+      case 3:
+        type = WarehouseAreaEnum.chubu;
+        break;
+      case 4:
+        type = WarehouseAreaEnum.kinki;
+        break;
+      case 5:
+        type = WarehouseAreaEnum.chugoku;
+        break;
+      case 6:
+        type = WarehouseAreaEnum.shikoku;
+        break;
+      case 7:
+        type = WarehouseAreaEnum.kyushu;
+        break;
+      case 8:
+        type = WarehouseAreaEnum.okinawa;
+        break;
+      case 9:
+        type = WarehouseAreaEnum.kanagawa;
+        break;
+      case 10:
+        type = WarehouseAreaEnum.chiba;
+        break;
+      case 11:
+        type = WarehouseAreaEnum.tokyo;
+        break;
+      case 12:
+        type = WarehouseAreaEnum.saitama;
+        break;
+      default:
+        throw Exception('Unknown type: $rowType');
+    }
+  }
+
+  String name() {
+    switch (type) {
+      case WarehouseAreaEnum.hokkaido:
+        return '北海道エリア';
+      case WarehouseAreaEnum.touhoku:
+        return '東北エリア';
+      case WarehouseAreaEnum.saitama:
+        return '埼玉エリア';
+      case WarehouseAreaEnum.tokyo:
+        return '東京エリア';
+      case WarehouseAreaEnum.chiba:
+        return '千葉エリア';
+      case WarehouseAreaEnum.kanagawa:
+        return '神奈川エリア';
+      case WarehouseAreaEnum.chubu:
+        return '中部エリア';
+      case WarehouseAreaEnum.kinki:
+        return '近畿エリア';
+      case WarehouseAreaEnum.chugoku:
+        return '中国エリア';
+      case WarehouseAreaEnum.shikoku:
+        return '四国エリア';
+      case WarehouseAreaEnum.kyushu:
+        return '九州エリア';
+      case WarehouseAreaEnum.okinawa:
+        return '沖縄エリア';
+      default:
+        return '';
+    }
+  }
+}

--- a/lib/Controller/WarehouseSearch/Result/warehouse_search_result_controller.dart
+++ b/lib/Controller/WarehouseSearch/Result/warehouse_search_result_controller.dart
@@ -9,35 +9,28 @@ import '../../../Model/Entity/Warehouse/info.dart';
 class WarehouseSearchResultController {
   /// キーワードから工場一覧を取得する
   /// [keyword]
-  Future<List<Warehouse>?> getWarehouseWithKeyword(
-      {required String keyword}) async {
+  Future<List<Warehouse>?> getWarehouseWithKeyword({required String keyword}) async {
     List<Warehouse>? warehouseList = [];
     for (int i = 1; i < 13; i++) {
-      List<Warehouse>? searchWarehouse =
-          await WarehouseService().getWarehouseList(i);
+      List<Warehouse>? searchWarehouse = await WarehouseService().getWarehouseList(i);
       if (searchWarehouse != null) {
         warehouseList.addAll(searchWarehouse);
       }
     }
-    List<Warehouse> sortList =
-        warehouseList.where((e) => e.name.contains(keyword)).toList();
+    List<Warehouse> sortList = warehouseList.where((e) => e.name.contains(keyword)).toList();
     Log.echo(sortList.toString());
     return sortList;
   }
 
   /// エリアID(List許容)から工場一覧を取得する
   /// [areaIds]
-  Future<List<Warehouse>?> getWarehouseWithArea(
-      {required List<int> areaIds}) async {
+  Future<List<Warehouse>?> getWarehouseWithArea({required int areaId}) async {
     List<Warehouse>? warehouseList = [];
-    for (int i = 0; i < areaIds.length; i++) {
-      List<Warehouse>? searchWarehouse =
-          await WarehouseService().getWarehouseList(areaIds[i]);
-      if (searchWarehouse != null) {
-        warehouseList.addAll(searchWarehouse);
-      }
+    List<Warehouse>? searchWarehouse = await WarehouseService().getWarehouseList(areaId);
+    if (searchWarehouse != null) {
+      warehouseList.addAll(searchWarehouse);
     }
-    Log.echo(warehouseList.toString());
+    Log.echo(warehouseList[0].name.toString());
     return warehouseList;
   }
 
@@ -45,8 +38,7 @@ class WarehouseSearchResultController {
   /// [warehouseId]
   Future<WarehouseInfo?> getWarehouseInfo({required int warehouseId}) async {
     WarehouseInfo? warehouseInfo;
-    final warehouse =
-        await WarehouseService().getWarehouseInfo(warehouseId: warehouseId);
+    final warehouse = await WarehouseService().getWarehouseInfo(warehouseId: warehouseId);
     if (warehouse == null) {
       // エラー
       return null;
@@ -59,8 +51,7 @@ class WarehouseSearchResultController {
       // エラー
       return null;
     }
-    warehouseInfo = searchInfo.warehouses!
-        .firstWhere((element) => element.warehouseId == warehouseId);
+    warehouseInfo = searchInfo.warehouses!.firstWhere((element) => element.warehouseId == warehouseId);
 
     return warehouseInfo;
   }

--- a/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
+++ b/lib/View/Component/CustomWidget/TrafficInformation/Detail/jam_info_place_tile.dart
@@ -1,5 +1,6 @@
 import 'package:fleet_tracker/Constants/Enum/traffic_detail_state_enum.dart';
 import 'package:fleet_tracker/View/Component/CustomWidget/custom_text.dart';
+import 'package:fleet_tracker/gen/colors.gen.dart';
 import 'package:flutter/material.dart';
 
 class JamInfoPlaceTile extends StatelessWidget {
@@ -92,7 +93,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                     flex: 2,
                     child: Container(
                       decoration: BoxDecoration(
-                        color: Colors.orange,
+                        color: type == TrafficDetailState.closure ? ColorName.trafficDetailStateClosure : ColorName.trafficDetailStateJam,
                         borderRadius: BorderRadius.circular(5),
                       ),
                       height: 25,
@@ -101,8 +102,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                         child: FittedBox(
                           fit: BoxFit.contain,
                           child: CustomText(
-                            text: TrafficDetailStateType(type.name)
-                                .JapaneseText(),
+                            text: TrafficDetailStateType(type.name).JapaneseText(),
                             color: Colors.white,
                             fontSize: 16,
                           ),
@@ -119,7 +119,7 @@ class JamInfoPlaceTile extends StatelessWidget {
                       child: CustomText(
                         text: content == null ? range! : '$content : $reason',
                         fontSize: 18,
-                        color: Colors.orange,
+                        color: type == TrafficDetailState.closure ? ColorName.trafficDetailStateClosure : ColorName.trafficDetailStateJam,
                         textOverflow: TextOverflow.clip,
                       ),
                     ),

--- a/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
+++ b/lib/View/Component/CustomWidget/UserInput/user_input_cell.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:fleet_tracker/Constants/Enum/warehouse_area_enum.dart';
 import 'package:fleet_tracker/Constants/strings.dart';
 import 'package:fleet_tracker/Controller/Component/user_input_circle_cell_controller.dart';
 import 'package:fleet_tracker/Controller/UserInput/user_input_top_controller.dart';
+import 'package:fleet_tracker/Model/Entity/Warehouse/area.dart';
 import 'package:fleet_tracker/Model/Entity/delay_information.dart';
 import 'package:fleet_tracker/Model/Entity/delay_time_detail.dart';
 import 'package:fleet_tracker/Service/API/Original/delay_service.dart';
@@ -50,8 +52,7 @@ class _UserInputCellState extends State<UserInputCell> {
   @override
   Widget build(BuildContext context) {
     final Size size = MediaQuery.of(context).size;
-    WarehouseDelayStateType stateType =
-        WarehouseDelayStateType(widget.delayStateType);
+    WarehouseDelayStateType stateType = WarehouseDelayStateType(widget.delayStateType);
     Log.echo('size: $size');
     return Padding(
       padding: const EdgeInsets.all(8.0),
@@ -78,8 +79,7 @@ class _UserInputCellState extends State<UserInputCell> {
                           child: Container(
                             decoration: BoxDecoration(
                               image: DecorationImage(
-                                image:
-                                    Assets.images.icons.factoryIcon.provider(),
+                                image: Assets.images.icons.factoryIcon.provider(),
                               ),
                             ),
                           ),
@@ -110,8 +110,7 @@ class _UserInputCellState extends State<UserInputCell> {
               height: 20,
             ),
             FutureBuilder(
-                future: controller.getAverageDelayState(
-                    warehouseId: widget.warehouseId),
+                future: controller.getAverageDelayState(warehouseId: widget.warehouseId),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState != ConnectionState.done) {
                     return const CirclarProgressIndicatorCell(height: 60);
@@ -122,8 +121,7 @@ class _UserInputCellState extends State<UserInputCell> {
                     if (type == null) {
                       // エラー
                     }
-                    WarehouseDelayStateType delayStateType =
-                        WarehouseDelayStateType(type!);
+                    WarehouseDelayStateType delayStateType = WarehouseDelayStateType(type!);
 
                     return Container(
                       height: 60,
@@ -164,9 +162,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                 Expanded(
                                   flex: 9,
                                   child: CustomText(
-                                    text: delayStateType
-                                        .title()
-                                        .replaceAll("\n", " "),
+                                    text: delayStateType.title().replaceAll("\n", " "),
                                   ),
                                 ),
                               ],
@@ -211,9 +207,7 @@ class _UserInputCellState extends State<UserInputCell> {
               height: 15,
             ),
             CustomText(
-              text: widget.enableAction
-                  ? '今の遅延状況は？ボタンを押して投稿！'
-                  : '現在の工場の遅延状態はこちら!',
+              text: widget.enableAction ? '今の遅延状況は？ボタンを押して投稿！' : '現在の工場の遅延状態はこちら!',
               fontSize: 14,
             ),
             SizedBox(
@@ -253,28 +247,19 @@ class _UserInputCellState extends State<UserInputCell> {
                             child: Container(
                               height: 60,
                               child: UserInputCircleCell(
-                                cellColor: onLoading
-                                    ? Colors.grey
-                                    : ColorName.stateNormal,
+                                cellColor: onLoading ? Colors.grey : ColorName.stateNormal,
                                 text: Strings.STATE_NORMAL_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
-                                        context: context,
-                                        title: 'エリア外から登録はできません',
-                                        content: Assets
-                                            .images.icons.errorDialogIcon
-                                            .image(),
-                                        detail: '該当のエリア内に移動してから再試行してください。',
-                                        buttonText: '戻る');
+                                        context: context, title: 'エリア外から登録はできません', content: Assets.images.icons.errorDialogIcon.image(), detail: '該当のエリア内に移動してから再試行してください。', buttonText: '戻る');
                                   } else {
                                     //平常のボタン処理
                                     if (!onLoading) {
                                       setState(() {
                                         onLoading = true;
                                       });
-                                      await UserInputCircleCellController()
-                                          .userInputCircleCellAction(
+                                      await UserInputCircleCellController().userInputCircleCellAction(
                                         type: WarehouseDelayState.normal.name,
                                         id: widget.warehouseId,
                                       );
@@ -295,28 +280,19 @@ class _UserInputCellState extends State<UserInputCell> {
                             child: Container(
                               height: 60,
                               child: UserInputCircleCell(
-                                cellColor: onLoading
-                                    ? Colors.grey
-                                    : ColorName.statePause,
+                                cellColor: onLoading ? Colors.grey : ColorName.statePause,
                                 text: Strings.STATE_PAUSE_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
-                                        context: context,
-                                        title: 'エリア外から登録はできません',
-                                        content: Assets
-                                            .images.icons.errorDialogIcon
-                                            .image(),
-                                        detail: '該当のエリア内に移動してから再試行してください。',
-                                        buttonText: '戻る');
+                                        context: context, title: 'エリア外から登録はできません', content: Assets.images.icons.errorDialogIcon.image(), detail: '該当のエリア内に移動してから再試行してください。', buttonText: '戻る');
                                   } else {
                                     //一時停止のボタン処理
                                     if (!onLoading) {
                                       setState(() {
                                         onLoading = true;
                                       });
-                                      await UserInputCircleCellController()
-                                          .userInputCircleCellAction(
+                                      await UserInputCircleCellController().userInputCircleCellAction(
                                         type: WarehouseDelayState.pause.name,
                                         id: widget.warehouseId,
                                       );
@@ -337,28 +313,19 @@ class _UserInputCellState extends State<UserInputCell> {
                             child: Container(
                               height: 60,
                               child: UserInputCircleCell(
-                                cellColor: onLoading
-                                    ? Colors.grey
-                                    : ColorName.stateHalfAnHour,
+                                cellColor: onLoading ? Colors.grey : ColorName.stateHalfAnHour,
                                 text: Strings.STATE_HALF_HOUR_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
-                                        context: context,
-                                        title: 'エリア外から登録はできません',
-                                        content: Assets
-                                            .images.icons.errorDialogIcon
-                                            .image(),
-                                        detail: '該当のエリア内に移動してから再試行してください。',
-                                        buttonText: '戻る');
+                                        context: context, title: 'エリア外から登録はできません', content: Assets.images.icons.errorDialogIcon.image(), detail: '該当のエリア内に移動してから再試行してください。', buttonText: '戻る');
                                   } else {
                                     //30分未満のボタン処理
                                     if (!onLoading) {
                                       setState(() {
                                         onLoading = true;
                                       });
-                                      await UserInputCircleCellController()
-                                          .userInputCircleCellAction(
+                                      await UserInputCircleCellController().userInputCircleCellAction(
                                         type: WarehouseDelayState.halfHour.name,
                                         id: widget.warehouseId,
                                       );
@@ -379,28 +346,19 @@ class _UserInputCellState extends State<UserInputCell> {
                             child: Container(
                               height: 60,
                               child: UserInputCircleCell(
-                                cellColor: onLoading
-                                    ? Colors.grey
-                                    : ColorName.stateAnHour,
+                                cellColor: onLoading ? Colors.grey : ColorName.stateAnHour,
                                 text: Strings.STATE_AN_HOUR_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
-                                        context: context,
-                                        title: 'エリア外から登録はできません',
-                                        content: Assets
-                                            .images.icons.errorDialogIcon
-                                            .image(),
-                                        detail: '該当のエリア内に移動してから再試行してください。',
-                                        buttonText: '戻る');
+                                        context: context, title: 'エリア外から登録はできません', content: Assets.images.icons.errorDialogIcon.image(), detail: '該当のエリア内に移動してから再試行してください。', buttonText: '戻る');
                                   } else {
                                     //1時間未満のボタン処理
                                     if (!onLoading) {
                                       setState(() {
                                         onLoading = true;
                                       });
-                                      await UserInputCircleCellController()
-                                          .userInputCircleCellAction(
+                                      await UserInputCircleCellController().userInputCircleCellAction(
                                         type: WarehouseDelayState.anHour.name,
                                         id: widget.warehouseId,
                                       );
@@ -423,30 +381,20 @@ class _UserInputCellState extends State<UserInputCell> {
                             child: Container(
                               height: 60,
                               child: UserInputCircleCell(
-                                cellColor: onLoading
-                                    ? Colors.grey
-                                    : ColorName.stateImpossible,
+                                cellColor: onLoading ? Colors.grey : ColorName.stateImpossible,
                                 text: Strings.STATE_IMPOSSIBLE_TITLE,
                                 onTap: () async {
                                   if (!widget.enableAction) {
                                     ErrorDialog().showErrorDialog(
-                                        context: context,
-                                        title: 'エリア外から登録はできません',
-                                        content: Assets
-                                            .images.icons.errorDialogIcon
-                                            .image(),
-                                        detail: '該当のエリア内に移動してから再試行してください。',
-                                        buttonText: '戻る');
+                                        context: context, title: 'エリア外から登録はできません', content: Assets.images.icons.errorDialogIcon.image(), detail: '該当のエリア内に移動してから再試行してください。', buttonText: '戻る');
                                   } else {
                                     //入庫不可のボタン処理
                                     if (!onLoading) {
                                       setState(() {
                                         onLoading = true;
                                       });
-                                      await UserInputCircleCellController()
-                                          .userInputCircleCellAction(
-                                        type:
-                                            WarehouseDelayState.impossible.name,
+                                      await UserInputCircleCellController().userInputCircleCellAction(
+                                        type: WarehouseDelayState.impossible.name,
                                         id: widget.warehouseId,
                                       );
                                       setState(() {
@@ -471,23 +419,20 @@ class _UserInputCellState extends State<UserInputCell> {
               height: 10,
             ),
             FutureBuilder(
-                future: DelayService().getDelayInformation(
-                    warehouseAreaId: widget.warehouseAreaId),
+                future: DelayService().getDelayInformation(warehouseAreaId: widget.warehouseAreaId),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState != ConnectionState.done) {
                     return CirclarProgressIndicatorCell(height: 30);
                   }
 
                   if (snapshot.hasData) {
-                    final List<DelayInformation>? delayInformation =
-                        snapshot.data;
+                    final List<DelayInformation>? delayInformation = snapshot.data;
 
                     if (delayInformation!.isEmpty) {
                       // エラー表示
                     }
                     // 現在の倉庫の遅延情報を抽出
-                    final currrentWarehouse = delayInformation.firstWhere(
-                        (element) => element.warehouseId == widget.warehouseId);
+                    final currrentWarehouse = delayInformation.firstWhere((element) => element.warehouseId == widget.warehouseId);
 
                     return Container(
                       child: FractionallySizedBox(
@@ -495,9 +440,7 @@ class _UserInputCellState extends State<UserInputCell> {
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            for (int i = 0;
-                                i < currrentWarehouse.delayTimeDetail.length;
-                                i++)
+                            for (int i = 0; i < currrentWarehouse.delayTimeDetail.length; i++)
                               Expanded(
                                 flex: 1,
                                 child: FractionallySizedBox(
@@ -509,9 +452,7 @@ class _UserInputCellState extends State<UserInputCell> {
                                     ),
                                     child: Center(
                                       child: CustomText(
-                                        text: currrentWarehouse
-                                            .delayTimeDetail[i].answerCount
-                                            .toString(),
+                                        text: currrentWarehouse.delayTimeDetail[i].answerCount.toString(),
                                       ),
                                     ),
                                   ),

--- a/lib/View/Component/WarehouseDetail/warehouse_detail_view.dart
+++ b/lib/View/Component/WarehouseDetail/warehouse_detail_view.dart
@@ -30,8 +30,7 @@ import '../../../Model/Entity/Warehouse/info.dart';
 import '../CustomWidget/Modal/warehouse_detail_info_modal.dart';
 
 class WarehouseDetailView extends StatefulWidget {
-  const WarehouseDetailView(
-      {super.key, required this.warehouseInfo, required this.functionType});
+  const WarehouseDetailView({super.key, required this.warehouseInfo, required this.functionType});
   final String functionType;
   final WarehouseInfo warehouseInfo;
   @override
@@ -45,8 +44,7 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
     /// コメント投稿と遅延情報登録の可否判定
     controller.initialize(widget.functionType);
     final Size size = MediaQuery.of(context).size;
-    WarehouseDelayStateType stateType =
-        WarehouseDelayStateType(widget.warehouseInfo.averageDelayState.name);
+    WarehouseDelayStateType stateType = WarehouseDelayStateType(widget.warehouseInfo.averageDelayState.name);
 
     return Scaffold(
       backgroundColor: ColorName.scaffoldBackground,
@@ -56,8 +54,7 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
         actions: [
           IconButton(
             onPressed: () {
-              WarehuseDetailInfoModal()
-                  .showInfoModal(context: context, size: size);
+              WarehuseDetailInfoModal().showInfoModal(context: context, size: size);
             },
             icon: const Icon(Icons.info),
           ),
@@ -70,8 +67,7 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
               //
               // 倉庫のマップ表示部
               FutureBuilder(
-                future: WarehouseService().getWarehouseInfo(
-                    warehouseId: widget.warehouseInfo.warehouseId),
+                future: WarehouseService().getWarehouseInfo(warehouseId: widget.warehouseInfo.warehouseId),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState != ConnectionState.done) {
                     return const CirclarProgressIndicatorCell(height: 130);
@@ -109,10 +105,8 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                   child: CommonCard(
                     content: UserInputCell(
                       warehouseName: widget.warehouseInfo.warehouseName,
-                      traficstateCountList:
-                          widget.warehouseInfo.delayTimeDetails,
-                      delayStateType:
-                          widget.warehouseInfo.averageDelayState.name,
+                      traficstateCountList: widget.warehouseInfo.delayTimeDetails,
+                      delayStateType: widget.warehouseInfo.averageDelayState.name,
                       enableAction: controller.enableAction,
                       warehouseId: widget.warehouseInfo.warehouseId,
                       warehouseAreaId: widget.warehouseInfo.warehouseAreaId,
@@ -145,57 +139,42 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                         heightFactor: 1,
                         child: Padding(
                           padding: const EdgeInsets.all(4.0),
-                          child: StatefulBuilder(builder:
-                              (BuildContext context, StateSetter setState) {
+                          child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
                             return CommonCard(
                               onTap: () async {
                                 await controller.favoriteButtonAction(
                                   warehouseId: widget.warehouseInfo.warehouseId,
                                 );
-                                await controller.getIsFavorite(
-                                    warehouseId:
-                                        widget.warehouseInfo.warehouseId);
+                                await controller.getIsFavorite(warehouseId: widget.warehouseInfo.warehouseId);
                                 setState(() {});
                               },
                               content: FutureBuilder<bool>(
-                                  future: controller.getIsFavorite(
-                                      warehouseId:
-                                          widget.warehouseInfo.warehouseId),
-                                  builder: (BuildContext context,
-                                      AsyncSnapshot<bool> snapshot) {
+                                  future: controller.getIsFavorite(warehouseId: widget.warehouseInfo.warehouseId),
+                                  builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
                                     if (snapshot.hasData) {
                                       bool isFavorite = snapshot.data!;
                                       return Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.start,
+                                        mainAxisAlignment: MainAxisAlignment.start,
                                         children: [
                                           Padding(
-                                            padding: const EdgeInsets.only(
-                                                left: 10, right: 5),
+                                            padding: const EdgeInsets.only(left: 10, right: 5),
                                             child: Icon(
-                                              isFavorite
-                                                  ? Icons.favorite
-                                                  : Icons.favorite_border,
+                                              isFavorite ? Icons.favorite : Icons.favorite_border,
                                               color: Colors.red,
                                             ),
                                           ),
                                           Padding(
                                             padding: const EdgeInsets.all(4.0),
-                                            child: CustomText(
-                                                text: isFavorite
-                                                    ? 'お気に入り登録済'
-                                                    : 'お気に入り'),
+                                            child: CustomText(text: isFavorite ? 'お気に入り登録済' : 'お気に入り'),
                                           ),
                                         ],
                                       );
                                     } else {
                                       return const Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.start,
+                                        mainAxisAlignment: MainAxisAlignment.start,
                                         children: [
                                           Padding(
-                                            padding: EdgeInsets.only(
-                                                left: 10, right: 5),
+                                            padding: EdgeInsets.only(left: 10, right: 5),
                                             child: Icon(
                                               Icons.favorite_border,
                                               color: Colors.red,
@@ -232,16 +211,14 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                 ),
               ),
               FutureBuilder(
-                  future: controller.getCommentList(
-                      warehouseId: widget.warehouseInfo.warehouseId),
+                  future: controller.getCommentList(warehouseId: widget.warehouseInfo.warehouseId),
                   builder: (context, snapshot) {
                     if (snapshot.connectionState != ConnectionState.done) {
                       return const CirclarProgressIndicatorCell(height: 400);
                     }
 
                     if (snapshot.hasData) {
-                      final List<Map<String, dynamic>> comentList =
-                          snapshot.data!;
+                      final List<Map<String, dynamic>> comentList = snapshot.data!;
                       Log.echo(comentList.length.toString());
                       if (comentList.isNotEmpty) {
                         return Container(
@@ -251,13 +228,10 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                               itemCount: snapshot.data!.length,
                               itemBuilder: (context, index) {
                                 return Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(vertical: 15),
+                                  padding: const EdgeInsets.symmetric(vertical: 15),
                                   child: CommentTile(
                                     userComment: comentList[index]['comment'],
-                                    createAt: DateFormat('yyyy年MM月dd日 HH時mm分')
-                                        .format(DateTime.parse(
-                                            comentList[index]['create_at'])),
+                                    createAt: DateFormat('yyyy年MM月dd日 HH時mm分').format(DateTime.parse(comentList[index]['create_at'])),
                                     userName: comentList[index]['name'],
                                   ),
                                 );
@@ -296,11 +270,7 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                     children: [
                       Padding(
                         padding: const EdgeInsets.all(8.0),
-                        child: CustomTextfield(
-                            isSerchIcon: false,
-                            hintText: '  コメントを書いてください',
-                            backgroundcolor: Colors.white,
-                            controller: controller.textEditingController),
+                        child: CustomTextfield(isSerchIcon: false, hintText: '  コメントを書いてください', backgroundcolor: Colors.white, controller: controller.textEditingController),
                       ),
                       Padding(
                           padding: const EdgeInsets.all(8.0),
@@ -312,8 +282,7 @@ class _WarehouseDetailViewState extends State<WarehouseDetailView> {
                               text: '投稿',
                               onTap: () async {
                                 controller.postComment(
-                                  content:
-                                      controller.textEditingController.text,
+                                  content: controller.textEditingController.text,
                                   warehouseId: widget.warehouseInfo.warehouseId,
                                 );
                                 setState(() {});

--- a/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
+++ b/lib/View/TrafficInformation/Detail/traffic_information_detail_view.dart
@@ -22,20 +22,28 @@ class TrafficInformationDetailView extends StatefulWidget {
   final bool provideSapa;
 
   @override
-  State<TrafficInformationDetailView> createState() =>
-      _TrafficInformationStateDetailView();
+  State<TrafficInformationDetailView> createState() => _TrafficInformationStateDetailView();
 }
 
-class _TrafficInformationStateDetailView
-    extends State<TrafficInformationDetailView> {
-  TrafficInformationDetailController controller =
-      TrafficInformationDetailController();
+class _TrafficInformationStateDetailView extends State<TrafficInformationDetailView> {
+  TrafficInformationDetailController controller = TrafficInformationDetailController();
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(
         title: '道路情報',
         isBackButton: true,
+        actions: [
+          IconButton(
+            onPressed: () {
+              setState(() {});
+            },
+            icon: const Icon(
+              Icons.restart_alt_outlined,
+              color: Colors.blue,
+            ),
+          ),
+        ],
       ),
       backgroundColor: ColorName.scaffoldBackground,
       body: SingleChildScrollView(
@@ -43,9 +51,8 @@ class _TrafficInformationStateDetailView
           children: <Widget>[
             FutureBuilder<TrafficDetail?>(
                 future: controller.getTrafficDetail(widget.roadId),
-                builder: (BuildContext context,
-                    AsyncSnapshot<TrafficDetail?> snapshot) {
-                  if (snapshot.hasData) {
+                builder: (BuildContext context, AsyncSnapshot<TrafficDetail?> snapshot) {
+                  if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
                     TrafficDetail trafficDetail = snapshot.data!;
                     return JamInfoTitle(
                       areaName: trafficDetail.data.areaName,
@@ -61,9 +68,8 @@ class _TrafficInformationStateDetailView
             ),
             FutureBuilder<List<TrafficIssue>?>(
                 future: controller.getTrafficIssueList(widget.roadId),
-                builder: (BuildContext context,
-                    AsyncSnapshot<List<TrafficIssue>?> snapshot) {
-                  if (snapshot.hasData) {
+                builder: (BuildContext context, AsyncSnapshot<List<TrafficIssue>?> snapshot) {
+                  if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
                     if (snapshot.data!.isNotEmpty) {
                       List<TrafficIssue> trafficIssueList = snapshot.data!;
                       return InfoContentCard(
@@ -117,30 +123,23 @@ class _TrafficInformationStateDetailView
             ),
             FutureBuilder<List<TrafficSapaInfo>?>(
                 future: controller.getTrafficSapaInfoList(widget.roadId),
-                builder: (BuildContext context,
-                    AsyncSnapshot<List<TrafficSapaInfo>?> snapshot) {
+                builder: (BuildContext context, AsyncSnapshot<List<TrafficSapaInfo>?> snapshot) {
                   if (widget.provideSapa) {
-                    if (snapshot.hasData) {
-                      List<TrafficSapaInfo> trafficSapaInfoList =
-                          snapshot.data!;
+                    if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
+                      List<TrafficSapaInfo> trafficSapaInfoList = snapshot.data!;
                       return Column(
                         children: <Widget>[
                           InfoContentCard(
                             title: 'SAPA情報',
                             children: <Widget>[
                               const SapaInfoHeader(),
-                              for (int i = 0;
-                                  i < trafficSapaInfoList.length;
-                                  i++) ...{
+                              for (int i = 0; i < trafficSapaInfoList.length; i++) ...{
                                 SapaInfoTile(
                                   name: trafficSapaInfoList[i].name,
                                   direction: trafficSapaInfoList[i].direction,
-                                  totalCongestion:
-                                      trafficSapaInfoList[i].totalCongestion,
-                                  smallCarCongestion:
-                                      trafficSapaInfoList[i].smallCarCongestion,
-                                  largeCarCongestion:
-                                      trafficSapaInfoList[i].largeCarCongestion,
+                                  totalCongestion: trafficSapaInfoList[i].totalCongestion,
+                                  smallCarCongestion: trafficSapaInfoList[i].smallCarCongestion,
+                                  largeCarCongestion: trafficSapaInfoList[i].largeCarCongestion,
                                 ),
                               },
                             ],

--- a/lib/View/TrafficInformation/traffic_information_top_view.dart
+++ b/lib/View/TrafficInformation/traffic_information_top_view.dart
@@ -10,20 +10,28 @@ class TrafficInformationTopView extends StatefulWidget {
   const TrafficInformationTopView({super.key});
 
   @override
-  State<TrafficInformationTopView> createState() =>
-      _TrafficInformationStateTopViewState();
+  State<TrafficInformationTopView> createState() => _TrafficInformationStateTopViewState();
 }
 
-class _TrafficInformationStateTopViewState
-    extends State<TrafficInformationTopView> {
-  TrafficInformationTopController controller =
-      TrafficInformationTopController();
+class _TrafficInformationStateTopViewState extends State<TrafficInformationTopView> {
+  TrafficInformationTopController controller = TrafficInformationTopController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(
         title: '交通情報',
+        actions: [
+          IconButton(
+            onPressed: () {
+              setState(() {});
+            },
+            icon: const Icon(
+              Icons.restart_alt_outlined,
+              color: Colors.blue,
+            ),
+          ),
+        ],
       ),
       body: Container(
         decoration: const BoxDecoration(
@@ -31,9 +39,8 @@ class _TrafficInformationStateTopViewState
         ),
         child: FutureBuilder<List<TrafficArea>?>(
           future: controller.getTraffiiAreatList(),
-          builder: (BuildContext context,
-              AsyncSnapshot<List<TrafficArea>?> snapshot) {
-            if (snapshot.hasData) {
+          builder: (BuildContext context, AsyncSnapshot<List<TrafficArea>?> snapshot) {
+            if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
               List<TrafficArea> prefectureInfoList = snapshot.data!;
               return ListView.builder(
                 itemCount: prefectureInfoList.length + 1,
@@ -45,8 +52,7 @@ class _TrafficInformationStateTopViewState
                   }
                   String prefectureName = prefectureInfoList[index].name;
                   int areaId = prefectureInfoList[index].id;
-                  List<TrafficRoad> prefecturalRoadList =
-                      prefectureInfoList[index].roads;
+                  List<TrafficRoad> prefecturalRoadList = prefectureInfoList[index].roads;
                   return TrafficInformationTileCell(
                     areaId: areaId,
                     count: prefectureInfoList[index].totalIssues,


### PR DESCRIPTION
## 概要
細かいviewの変更

## 変更点

-getWarehouseWithArea関数をview側で繰り返した方が良い感じにできるため、繰り返し処理を削除
- 交通情報の遅延と、通行止めの色をわかりやすい様に変更
- 交通情報のリロードボタン追加
- enumからエリア名を取得してこれるよう追加
- 改行で変なとこ編集しちゃってるの多いかもスマセン

## スクリーンショット
![Screenshot_1720450707](https://github.com/SEIZENSETSU/fleet-tracker-flutter/assets/57495289/f7d175d5-7f22-4df0-b30b-bea1c5b350fb)


## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda