### PR TITLE
fix: 時間差がマイナスにならないように修正

### DIFF
--- a/lib/Controller/Component/user_input_circle_cell_controller.dart
+++ b/lib/Controller/Component/user_input_circle_cell_controller.dart
@@ -52,7 +52,7 @@ class UserInputCircleCellController {
     }
     final DateTime currentDateTime = DateTime.now();
 
-    Duration interval = DateTime.parse(posted).difference(currentDateTime);
+    Duration interval = currentDateTime.difference(DateTime.parse(posted));
 
     Log.echo('経過時間は${interval.inHours}時間です');
 


### PR DESCRIPTION
## 概要
登録の時間差がマイナスにならないように修正

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- intervalのdifferenceの前後の値を入れ替え
- Duration interval = currentDateTime.difference(DateTime.parse(posted));


## スクリーンショット
位置情報取れなくてわからんので無し

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda